### PR TITLE
Add voice dictation

### DIFF
--- a/packages/back-end/src/enterprise/services/ai.ts
+++ b/packages/back-end/src/enterprise/services/ai.ts
@@ -241,6 +241,41 @@ export const secondsUntilAICanBeUsedAgainForEmbeddings = async (
   return secondsUntilAICanBeUsedAgainForProvider(context, provider);
 };
 
+export const secondsUntilAICanBeUsedAgainForSTT = async (
+  context: ReqContext | ApiReqContext,
+): Promise<number> => {
+  if (!IS_CLOUD) return 0;
+  const { sttModel } = await getAISettingsForOrg(context);
+  const provider = sttModel
+    ? (getProviderForAIModel("stt", sttModel) ?? undefined)
+    : undefined;
+  return secondsUntilAICanBeUsedAgainForProvider(context, provider);
+};
+
+// Audio carries no tokens, so dictation is charged against the same ledger by
+// size. Deliberately coarse — it only has to make repeated dictation trip the
+// cap and track provider cost (billed per minute) monotonically.
+//
+// ponytail: byte proxy rather than a real minutes ledger. Unlike charging the
+// transcript it can't be gamed with silence. Add a minutes counter to
+// AITokenUsageModel if dictation spend needs accurate attribution.
+const STT_TOKENS_PER_KB = 1;
+
+export const recordSTTUsage = async (
+  context: ReqContext | ApiReqContext,
+  audioBytes: number,
+  provider: AIProvider,
+): Promise<void> => {
+  if (!IS_CLOUD) return;
+  const { keySource } = await getAISettingsForOrg(context);
+  // The org pays its own provider directly, so nothing to meter.
+  if (keySource[provider] === "organization") return;
+  await updateTokenUsage({
+    numTokensUsed: Math.ceil((audioBytes / 1024) * STT_TOKENS_PER_KB),
+    organization: context.org,
+  });
+};
+
 const constructMessages = (
   prompt: string,
   instructions?: string,

--- a/packages/back-end/src/enterprise/services/stt.ts
+++ b/packages/back-end/src/enterprise/services/stt.ts
@@ -1,0 +1,97 @@
+import { experimental_transcribe as transcribe } from "ai";
+import { createOpenAI } from "@ai-sdk/openai";
+import FormData from "form-data";
+import { getProviderFromSTTModel } from "shared/ai";
+import type { ReqContext } from "back-end/types/request";
+import { getAISettingsForOrg } from "back-end/src/services/organizations";
+import { missingAIKeyMessage } from "back-end/src/services/aiCredentials";
+import { fetch } from "back-end/src/util/http.util";
+
+// Mistral's transcription endpoint is a drop-in for OpenAI's, so both run
+// through the AI SDK's transcribe() with only the base URL swapped.
+const MISTRAL_BASE_URL = "https://api.mistral.ai/v1";
+
+// xAI is the exception: its STT model is served from /v1/stt with its own
+// multipart contract, not an OpenAI-compatible /v1/audio/transcriptions.
+const XAI_STT_URL = "https://api.x.ai/v1/stt";
+
+// The extension is cosmetic to xAI (it sniffs the bytes) but the field has to
+// carry a filename or the multipart part is rejected.
+function filenameForMimeType(mimeType: string): string {
+  const subtype = mimeType.split(";")[0].split("/")[1] || "webm";
+  return `dictation.${subtype}`;
+}
+
+async function transcribeWithXai(
+  apiKey: string,
+  audio: Buffer,
+  mimeType: string,
+): Promise<string> {
+  const form = new FormData();
+  form.append("file", audio, {
+    filename: filenameForMimeType(mimeType),
+    contentType: mimeType,
+  });
+
+  const res = await fetch(XAI_STT_URL, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}` },
+    body: form,
+  });
+  if (!res.ok) {
+    throw new Error(`Transcription failed (xAI returned HTTP ${res.status})`);
+  }
+  const json = (await res.json()) as { text?: string };
+  return json.text ?? "";
+}
+
+/**
+ * Transcribe a recorded audio clip using the org's resolved dictation model.
+ *
+ * `mimeType` comes from the request's Content-Type — the browser picks the
+ * container, so it varies by platform (Safari mp4, Chrome webm).
+ *
+ * ponytail: no usage accounting — the org AI cap counts tokens and audio
+ * minutes aren't tokens. Add a minutes counter to AITokenUsageModel if
+ * dictation cost shows up.
+ */
+export async function transcribeAudio(
+  context: ReqContext,
+  audio: Buffer,
+  mimeType: string,
+): Promise<string> {
+  const settings = await getAISettingsForOrg(context, true);
+  const { sttModel } = settings;
+
+  if (!sttModel) {
+    throw new Error(
+      "No transcription model is available. Add an OpenAI, xAI, or Mistral API key under Settings → AI & Prompts.",
+    );
+  }
+
+  const provider = getProviderFromSTTModel(sttModel);
+  const apiKey = {
+    openai: settings.openAIAPIKey,
+    xai: settings.xaiAPIKey,
+    mistral: settings.mistralAPIKey,
+  }[provider as "openai" | "xai" | "mistral"];
+
+  if (!apiKey) {
+    throw new Error(missingAIKeyMessage(provider));
+  }
+
+  if (provider === "xai") {
+    return transcribeWithXai(apiKey, audio, mimeType);
+  }
+
+  const openai = createOpenAI({
+    apiKey,
+    ...(provider === "mistral" ? { baseURL: MISTRAL_BASE_URL } : {}),
+  });
+  // No mediaType argument: the provider detects the container from the bytes.
+  const { text } = await transcribe({
+    model: openai.transcription(sttModel),
+    audio,
+  });
+  return text;
+}

--- a/packages/back-end/src/enterprise/services/stt.ts
+++ b/packages/back-end/src/enterprise/services/stt.ts
@@ -7,33 +7,21 @@ import { getAISettingsForOrg } from "back-end/src/services/organizations";
 import { missingAIKeyMessage } from "back-end/src/services/aiCredentials";
 import { fetch } from "back-end/src/util/http.util";
 
-// Mistral's transcription endpoint is a drop-in for OpenAI's, so both run
-// through the AI SDK's transcribe() with only the base URL swapped.
-const MISTRAL_BASE_URL = "https://api.mistral.ai/v1";
-
-// xAI is the exception: its STT model is served from /v1/stt with its own
-// multipart contract, not an OpenAI-compatible /v1/audio/transcriptions.
-const XAI_STT_URL = "https://api.x.ai/v1/stt";
-
-// The extension is cosmetic to xAI (it sniffs the bytes) but the field has to
-// carry a filename or the multipart part is rejected.
-function filenameForMimeType(mimeType: string): string {
-  const subtype = mimeType.split(";")[0].split("/")[1] || "webm";
-  return `dictation.${subtype}`;
-}
-
+// xAI serves STT from /v1/stt with its own multipart contract rather than an
+// OpenAI-compatible /v1/audio/transcriptions.
 async function transcribeWithXai(
   apiKey: string,
   audio: Buffer,
   mimeType: string,
 ): Promise<string> {
   const form = new FormData();
+  // The extension is cosmetic (xAI sniffs the bytes) but the part needs a name.
   form.append("file", audio, {
-    filename: filenameForMimeType(mimeType),
+    filename: `dictation.${mimeType.split(";")[0].split("/")[1] || "webm"}`,
     contentType: mimeType,
   });
 
-  const res = await fetch(XAI_STT_URL, {
+  const res = await fetch("https://api.x.ai/v1/stt", {
     method: "POST",
     headers: { Authorization: `Bearer ${apiKey}` },
     body: form,
@@ -41,19 +29,15 @@ async function transcribeWithXai(
   if (!res.ok) {
     throw new Error(`Transcription failed (xAI returned HTTP ${res.status})`);
   }
-  const json = (await res.json()) as { text?: string };
-  return json.text ?? "";
+  return ((await res.json()) as { text?: string }).text ?? "";
 }
 
 /**
- * Transcribe a recorded audio clip using the org's resolved dictation model.
+ * Transcribe a recorded clip with the org's resolved dictation model.
+ * `mimeType` is the browser's container choice (Safari mp4, Chrome webm).
  *
- * `mimeType` comes from the request's Content-Type — the browser picks the
- * container, so it varies by platform (Safari mp4, Chrome webm).
- *
- * ponytail: no usage accounting — the org AI cap counts tokens and audio
- * minutes aren't tokens. Add a minutes counter to AITokenUsageModel if
- * dictation cost shows up.
+ * ponytail: no usage accounting — the org AI cap counts tokens, and audio
+ * minutes aren't tokens. Add a minutes counter if dictation cost shows up.
  */
 export async function transcribeAudio(
   context: ReqContext,
@@ -62,33 +46,28 @@ export async function transcribeAudio(
 ): Promise<string> {
   const settings = await getAISettingsForOrg(context, true);
   const { sttModel } = settings;
-
   if (!sttModel) {
-    throw new Error(
-      "No transcription model is available. Add an OpenAI, xAI, or Mistral API key under Settings → AI & Prompts.",
-    );
+    throw new Error("No transcription model is available.");
   }
 
   const provider = getProviderFromSTTModel(sttModel);
-  const apiKey = {
-    openai: settings.openAIAPIKey,
-    xai: settings.xaiAPIKey,
-    mistral: settings.mistralAPIKey,
-  }[provider as "openai" | "xai" | "mistral"];
-
+  const apiKey =
+    provider === "xai"
+      ? settings.xaiAPIKey
+      : provider === "mistral"
+        ? settings.mistralAPIKey
+        : settings.openAIAPIKey;
   if (!apiKey) {
     throw new Error(missingAIKeyMessage(provider));
   }
 
-  if (provider === "xai") {
-    return transcribeWithXai(apiKey, audio, mimeType);
-  }
+  if (provider === "xai") return transcribeWithXai(apiKey, audio, mimeType);
 
+  // Mistral's endpoint is a drop-in for OpenAI's, so only the base URL differs.
   const openai = createOpenAI({
     apiKey,
-    ...(provider === "mistral" ? { baseURL: MISTRAL_BASE_URL } : {}),
+    ...(provider === "mistral" ? { baseURL: "https://api.mistral.ai/v1" } : {}),
   });
-  // No mediaType argument: the provider detects the container from the bytes.
   const { text } = await transcribe({
     model: openai.transcription(sttModel),
     audio,

--- a/packages/back-end/src/enterprise/services/stt.ts
+++ b/packages/back-end/src/enterprise/services/stt.ts
@@ -18,12 +18,9 @@ const STT_ENDPOINTS: Partial<Record<AIProvider, string>> = {
  * Transcribe a recorded clip with the org's resolved dictation model.
  * `mimeType` is the browser's container choice (Safari mp4, Chrome webm).
  *
- * Posted as multipart directly rather than through the AI SDK's transcribe():
- * that helper ignores a caller-supplied media type and sniffs the bytes, and
- * its signature table has no webm entry and matches mp4's `ftyp` at offset 0
- * (real files carry it at offset 4). Both fall through to a hardcoded
- * audio/wav, so every container a browser can record is uploaded as
- * `audio.wav` and rejected by the provider.
+ * Multipart directly, not the AI SDK's transcribe(): it ignores the caller's
+ * media type, and its sniffer misses both webm and mp4, defaulting them to
+ * audio/wav — which every provider then rejects.
  *
  * Callers must gate on secondsUntilAICanBeUsedAgainForSTT first; this records
  * the usage that gate reads, on success only.
@@ -58,7 +55,7 @@ export async function transcribeAudio(
   const form = new FormData();
   // Providers key off the extension, so it has to match the actual container.
   form.append("file", audio, {
-    filename: `dictation.${extensionFor(mimeType)}`,
+    filename: `dictation.${mimeType.split(";")[0].split("/")[1] || "webm"}`,
     contentType: mimeType,
   });
   // xAI's /v1/stt serves one model and documents no `model` field.
@@ -74,16 +71,8 @@ export async function transcribeAudio(
   }
   const text = ((await res.json()) as { text?: string }).text ?? "";
 
-  // Charged only after the provider accepted the audio. A rejection costs
-  // GrowthBook nothing, so billing the org's shared quota for one would let
-  // junk uploads deny the org its own legitimate AI use.
+  // Success only: a rejection costs nothing, so billing for it would let junk
+  // uploads deny the org its own AI use.
   await recordSTTUsage(context, audio.length, provider);
   return text;
-}
-
-// "audio/webm;codecs=opus" -> "webm". Keep in sync with the recorder's
-// preference list in useDictation.ts, which only offers containers every
-// endpoint above accepts.
-function extensionFor(mimeType: string): string {
-  return mimeType.split(";")[0].split("/")[1] || "webm";
 }

--- a/packages/back-end/src/enterprise/services/stt.ts
+++ b/packages/back-end/src/enterprise/services/stt.ts
@@ -1,43 +1,32 @@
-import { experimental_transcribe as transcribe } from "ai";
-import { createOpenAI } from "@ai-sdk/openai";
 import FormData from "form-data";
-import { getProviderFromSTTModel } from "shared/ai";
+import { AIProvider, getProviderFromSTTModel } from "shared/ai";
 import type { ReqContext } from "back-end/types/request";
 import { getAISettingsForOrg } from "back-end/src/services/organizations";
 import { missingAIKeyMessage } from "back-end/src/services/aiCredentials";
+import { recordSTTUsage } from "back-end/src/enterprise/services/ai";
 import { fetch } from "back-end/src/util/http.util";
 
-// xAI serves STT from /v1/stt with its own multipart contract rather than an
-// OpenAI-compatible /v1/audio/transcriptions.
-async function transcribeWithXai(
-  apiKey: string,
-  audio: Buffer,
-  mimeType: string,
-): Promise<string> {
-  const form = new FormData();
-  // The extension is cosmetic (xAI sniffs the bytes) but the part needs a name.
-  form.append("file", audio, {
-    filename: `dictation.${mimeType.split(";")[0].split("/")[1] || "webm"}`,
-    contentType: mimeType,
-  });
-
-  const res = await fetch("https://api.x.ai/v1/stt", {
-    method: "POST",
-    headers: { Authorization: `Bearer ${apiKey}` },
-    body: form,
-  });
-  if (!res.ok) {
-    throw new Error(`Transcription failed (xAI returned HTTP ${res.status})`);
-  }
-  return ((await res.json()) as { text?: string }).text ?? "";
-}
+// OpenAI and Mistral share OpenAI's /v1/audio/transcriptions contract; xAI
+// serves its own /v1/stt. All three answer with `{ text }`.
+const STT_ENDPOINTS: Partial<Record<AIProvider, string>> = {
+  openai: "https://api.openai.com/v1/audio/transcriptions",
+  mistral: "https://api.mistral.ai/v1/audio/transcriptions",
+  xai: "https://api.x.ai/v1/stt",
+};
 
 /**
  * Transcribe a recorded clip with the org's resolved dictation model.
  * `mimeType` is the browser's container choice (Safari mp4, Chrome webm).
  *
- * ponytail: no usage accounting — the org AI cap counts tokens, and audio
- * minutes aren't tokens. Add a minutes counter if dictation cost shows up.
+ * Posted as multipart directly rather than through the AI SDK's transcribe():
+ * that helper ignores a caller-supplied media type and sniffs the bytes, and
+ * its signature table has no webm entry and matches mp4's `ftyp` at offset 0
+ * (real files carry it at offset 4). Both fall through to a hardcoded
+ * audio/wav, so every container a browser can record is uploaded as
+ * `audio.wav` and rejected by the provider.
+ *
+ * Callers must gate on secondsUntilAICanBeUsedAgainForSTT first; this records
+ * the usage that gate reads.
  */
 export async function transcribeAudio(
   context: ReqContext,
@@ -61,16 +50,36 @@ export async function transcribeAudio(
     throw new Error(missingAIKeyMessage(provider));
   }
 
-  if (provider === "xai") return transcribeWithXai(apiKey, audio, mimeType);
+  const url = STT_ENDPOINTS[provider];
+  if (!url) {
+    throw new Error(`${sttModel} cannot be used for transcription.`);
+  }
 
-  // Mistral's endpoint is a drop-in for OpenAI's, so only the base URL differs.
-  const openai = createOpenAI({
-    apiKey,
-    ...(provider === "mistral" ? { baseURL: "https://api.mistral.ai/v1" } : {}),
+  await recordSTTUsage(context, audio.length, provider);
+
+  const form = new FormData();
+  // Providers key off the extension, so it has to match the actual container.
+  form.append("file", audio, {
+    filename: `dictation.${extensionFor(mimeType)}`,
+    contentType: mimeType,
   });
-  const { text } = await transcribe({
-    model: openai.transcription(sttModel),
-    audio,
+  // xAI's /v1/stt serves one model and documents no `model` field.
+  if (provider !== "xai") form.append("model", sttModel);
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}` },
+    body: form,
   });
-  return text;
+  if (!res.ok) {
+    throw new Error(`Transcription failed (HTTP ${res.status})`);
+  }
+  return ((await res.json()) as { text?: string }).text ?? "";
+}
+
+// "audio/webm;codecs=opus" -> "webm". Keep in sync with the recorder's
+// preference list in useDictation.ts, which only offers containers every
+// endpoint above accepts.
+function extensionFor(mimeType: string): string {
+  return mimeType.split(";")[0].split("/")[1] || "webm";
 }

--- a/packages/back-end/src/enterprise/services/stt.ts
+++ b/packages/back-end/src/enterprise/services/stt.ts
@@ -26,7 +26,7 @@ const STT_ENDPOINTS: Partial<Record<AIProvider, string>> = {
  * `audio.wav` and rejected by the provider.
  *
  * Callers must gate on secondsUntilAICanBeUsedAgainForSTT first; this records
- * the usage that gate reads.
+ * the usage that gate reads, on success only.
  */
 export async function transcribeAudio(
   context: ReqContext,
@@ -55,8 +55,6 @@ export async function transcribeAudio(
     throw new Error(`${sttModel} cannot be used for transcription.`);
   }
 
-  await recordSTTUsage(context, audio.length, provider);
-
   const form = new FormData();
   // Providers key off the extension, so it has to match the actual container.
   form.append("file", audio, {
@@ -74,7 +72,13 @@ export async function transcribeAudio(
   if (!res.ok) {
     throw new Error(`Transcription failed (HTTP ${res.status})`);
   }
-  return ((await res.json()) as { text?: string }).text ?? "";
+  const text = ((await res.json()) as { text?: string }).text ?? "";
+
+  // Charged only after the provider accepted the audio. A rejection costs
+  // GrowthBook nothing, so billing the org's shared quota for one would let
+  // junk uploads deny the org its own legitimate AI use.
+  await recordSTTUsage(context, audio.length, provider);
+  return text;
 }
 
 // "audio/webm;codecs=opus" -> "webm". Keep in sync with the recorder's

--- a/packages/back-end/src/models/AITokenUsageModel.ts
+++ b/packages/back-end/src/models/AITokenUsageModel.ts
@@ -46,28 +46,30 @@ export const updateTokenUsage = async ({
       lastResetAt: new Date().getTime(),
     };
   }
-  let tokenUsage = await AITokenUsageModel.findOne({
-    organization: organization.id,
-  });
-
-  if (!tokenUsage) {
-    tokenUsage = await AITokenUsageModel.create({
-      organization: organization.id,
-      numTokensUsed: 0,
-      lastResetAt: new Date().getTime(),
-    });
-  }
-
-  const lastResetAt = tokenUsage.lastResetAt;
   const now = new Date().getTime();
-  if (now - lastResetAt > RESET_INTERVAL) {
-    tokenUsage.lastResetAt = now;
-    tokenUsage.numTokensUsed = 0;
-  }
 
-  tokenUsage.numTokensUsed += numTokensUsed;
+  // Roll the window first. Self-limiting under concurrency: once one writer
+  // sets lastResetAt to now, the filter stops matching for everyone else.
+  await AITokenUsageModel.updateOne(
+    {
+      organization: organization.id,
+      lastResetAt: { $lt: now - RESET_INTERVAL },
+    },
+    { $set: { numTokensUsed: 0, lastResetAt: now } },
+  );
 
-  await tokenUsage.save();
+  // $inc rather than read-modify-save. Concurrent AI calls used to read the
+  // same total and overwrite each other's charge, undercounting usage against
+  // the daily cap. dailyLimit is set explicitly on insert rather than left to
+  // the schema default, because an undefined limit reads as "never over cap".
+  const tokenUsage = await AITokenUsageModel.findOneAndUpdate(
+    { organization: organization.id },
+    {
+      $inc: { numTokensUsed },
+      $setOnInsert: { lastResetAt: now, dailyLimit: DAILY_TOKEN_LIMIT },
+    },
+    { new: true, upsert: true },
+  );
 
   return toInterface(tokenUsage);
 };

--- a/packages/back-end/src/routers/ai/ai.controller.ts
+++ b/packages/back-end/src/routers/ai/ai.controller.ts
@@ -25,6 +25,7 @@ import {
 import { AuthRequest } from "back-end/src/types/AuthRequest";
 import {
   secondsUntilAICanBeUsedAgainForPrompt,
+  secondsUntilAICanBeUsedAgainForSTT,
   simpleCompletion,
 } from "back-end/src/enterprise/services/ai";
 import { runAIEnabledGates } from "back-end/src/enterprise/services/ai-access";
@@ -325,6 +326,17 @@ export async function postTranscribe(req: AuthRequest, res: Response) {
     return res.status(400).json({
       status: 400,
       message: "No audio was uploaded",
+    });
+  }
+
+  // Managed Cloud keys are GrowthBook's spend, so the org's daily cap applies
+  // before we call a provider.
+  const secondsUntilReset = await secondsUntilAICanBeUsedAgainForSTT(context);
+  if (secondsUntilReset > 0) {
+    return res.status(429).json({
+      status: 429,
+      message: "Over AI usage limits",
+      retryAfter: secondsUntilReset,
     });
   }
 

--- a/packages/back-end/src/routers/ai/ai.controller.ts
+++ b/packages/back-end/src/routers/ai/ai.controller.ts
@@ -27,6 +27,8 @@ import {
   secondsUntilAICanBeUsedAgainForPrompt,
   simpleCompletion,
 } from "back-end/src/enterprise/services/ai";
+import { runAIEnabledGates } from "back-end/src/enterprise/services/ai-access";
+import { transcribeAudio } from "back-end/src/enterprise/services/stt";
 import { getTokensUsedByOrganization } from "back-end/src/models/AITokenUsageModel";
 import { IS_CLOUD } from "back-end/src/util/secrets";
 
@@ -311,4 +313,29 @@ export async function postReformat(
       output: aiResults,
     },
   });
+}
+
+/**
+ * Transcribe a dictated audio clip. The body is raw audio bytes (see the
+ * route's bodyParser.raw), so there is nothing for a Zod validator to check —
+ * the model choice is resolved server-side from org settings.
+ */
+export async function postTranscribe(req: AuthRequest, res: Response) {
+  const context = getContextFromReq(req);
+  if (!(await runAIEnabledGates(context, res))) return;
+
+  const audio = req.body;
+  if (!Buffer.isBuffer(audio) || !audio.length) {
+    return res.status(400).json({
+      status: 400,
+      message: "No audio was uploaded",
+    });
+  }
+
+  const text = await transcribeAudio(
+    context,
+    audio,
+    req.headers["content-type"] || "audio/webm",
+  );
+  return res.status(200).json({ status: 200, text });
 }

--- a/packages/back-end/src/routers/ai/ai.controller.ts
+++ b/packages/back-end/src/routers/ai/ai.controller.ts
@@ -315,11 +315,7 @@ export async function postReformat(
   });
 }
 
-/**
- * Transcribe a dictated audio clip. The body is raw audio bytes (see the
- * route's bodyParser.raw), so there is nothing for a Zod validator to check —
- * the model choice is resolved server-side from org settings.
- */
+/** Transcribe a dictated clip. Raw audio body, so no Zod validator applies. */
 export async function postTranscribe(req: AuthRequest, res: Response) {
   const context = getContextFromReq(req);
   if (!(await runAIEnabledGates(context, res))) return;
@@ -332,10 +328,7 @@ export async function postTranscribe(req: AuthRequest, res: Response) {
     });
   }
 
-  const text = await transcribeAudio(
-    context,
-    audio,
-    req.headers["content-type"] || "audio/webm",
-  );
+  const contentType = req.headers["content-type"] || "audio/webm";
+  const text = await transcribeAudio(context, audio, contentType);
   return res.status(200).json({ status: 200, text });
 }

--- a/packages/back-end/src/routers/ai/ai.router.ts
+++ b/packages/back-end/src/routers/ai/ai.router.ts
@@ -79,10 +79,9 @@ router.post(
   AIController.postReformat,
 );
 
-// Raw audio in, transcript out. The app-level bodyParser.json only claims
-// `application/json`, so an `audio/*` body reaches this parser untouched — the
-// same arrangement the upload router uses for images. 25mb is OpenAI's file
-// limit, the tightest of the three providers.
+// The app-level bodyParser.json only claims `application/json`, so an
+// `audio/*` body reaches this parser untouched — same as the upload router.
+// 25mb is OpenAI's file limit, the tightest of the three providers.
 router.post(
   "/transcribe",
   bodyParser.raw({ type: "audio/*", limit: "25mb" }),

--- a/packages/back-end/src/routers/ai/ai.router.ts
+++ b/packages/back-end/src/routers/ai/ai.router.ts
@@ -1,3 +1,4 @@
+import bodyParser from "body-parser";
 import express from "express";
 import { z } from "zod";
 import { wrapController } from "back-end/src/routers/wrapController";
@@ -76,6 +77,16 @@ router.post(
     }),
   }),
   AIController.postReformat,
+);
+
+// Raw audio in, transcript out. The app-level bodyParser.json only claims
+// `application/json`, so an `audio/*` body reaches this parser untouched — the
+// same arrangement the upload router uses for images. 25mb is OpenAI's file
+// limit, the tightest of the three providers.
+router.post(
+  "/transcribe",
+  bodyParser.raw({ type: "audio/*", limit: "25mb" }),
+  AIController.postTranscribe,
 );
 
 export { router as aiRouter };

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -979,7 +979,7 @@ export async function getOrganization(
 
   // Returned here so every page can gate AI affordances off the org's real key
   // state without a second request. The keys never leave the back end.
-  const { keySource } = await getAISettingsForOrg(context);
+  const { keySource, sttModel } = await getAISettingsForOrg(context);
   const aiKeyProviders = AI_PROVIDERS.filter((p) => keySource[p] !== "none");
 
   // Teams were already loaded (unfiltered) by the auth middleware
@@ -1024,6 +1024,10 @@ export async function getOrganization(
     subscription: license ? getSubscriptionFromLicense(license) : null,
     agreements: agreementsAgreed || [],
     aiKeyProviders,
+    // Resolved server-side rather than re-derived in the front-end: the
+    // settings dropdown only filters by key on Cloud, so a front-end guess
+    // would disagree with what the transcribe route actually does.
+    sttModel,
     watching: {
       experiments: watch?.experiments || [],
       features: watch?.features || [],

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1024,9 +1024,7 @@ export async function getOrganization(
     subscription: license ? getSubscriptionFromLicense(license) : null,
     agreements: agreementsAgreed || [],
     aiKeyProviders,
-    // Resolved server-side rather than re-derived in the front-end: the
-    // settings dropdown only filters by key on Cloud, so a front-end guess
-    // would disagree with what the transcribe route actually does.
+    // Resolved here so the front-end can't disagree with the transcribe route.
     sttModel,
     watching: {
       experiments: watch?.experiments || [],

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -39,9 +39,8 @@ import {
   CLOUD_MANAGED_VISUAL_EDITOR_AI_MODEL,
   DEFAULT_EMBEDDING_MODEL,
   EmbeddingModel,
-  CLOUD_MANAGED_STT_MODEL,
-  SELF_HOSTED_DEFAULT_STT_MODELS,
   STTModel,
+  resolveDefaultSTTModel,
   getProviderForAIModel,
 } from "shared/ai";
 import { SSOConnectionInterface } from "shared/types/sso-connection";
@@ -383,16 +382,13 @@ export async function getAISettingsForOrg(
       ? CLOUD_MANAGED_IMAGE_MODEL
       : GEMINI_IMAGE_MODEL);
 
-  // Cloud prefers the managed Grok model, then both deployments walk the
-  // provider list so a missing key degrades instead of disabling dictation.
   const sttModel: STTModel | null = !aiEnabled
     ? null
     : getAllowedAIModel("stt", context.org.settings?.sttModel, keySource) ||
-      (IS_CLOUD && keySource.xai !== "none" ? CLOUD_MANAGED_STT_MODEL : null) ||
-      SELF_HOSTED_DEFAULT_STT_MODELS.find(
-        ([provider]) => keySource[provider] !== "none",
-      )?.[1] ||
-      null;
+      resolveDefaultSTTModel(
+        AI_PROVIDERS.filter((p) => keySource[p] !== "none"),
+        IS_CLOUD,
+      );
 
   return {
     aiEnabled,

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -39,6 +39,9 @@ import {
   CLOUD_MANAGED_VISUAL_EDITOR_AI_MODEL,
   DEFAULT_EMBEDDING_MODEL,
   EmbeddingModel,
+  CLOUD_MANAGED_STT_MODEL,
+  SELF_HOSTED_DEFAULT_STT_MODELS,
+  STTModel,
   getProviderForAIModel,
 } from "shared/ai";
 import { SSOConnectionInterface } from "shared/types/sso-connection";
@@ -311,6 +314,12 @@ export async function getAISettingsForOrg(
   keySource: Record<AIProvider, AIKeySource>;
   defaultAIModel: AIModel;
   embeddingModel: EmbeddingModel;
+  // Transcription model for voice dictation, or null when no provider with a
+  // key serves one. Unlike embeddingModel this is nullable on purpose: the
+  // embedding default is only reached by an explicit "Regenerate" click that
+  // surfaces its own error, while a mic button that renders and then fails
+  // after the user has spoken is worse than no mic button.
+  sttModel: STTModel | null;
   // Resolved Visual Editor overrides — both already fall back to a
   // sensible default so callers don't need their own resolution logic.
   visualEditorAIModel: AIModel;
@@ -376,6 +385,16 @@ export async function getAISettingsForOrg(
       ? CLOUD_MANAGED_IMAGE_MODEL
       : GEMINI_IMAGE_MODEL);
 
+  // Cloud prefers the managed Grok STT model; both Cloud and self-hosted then
+  // walk the provider list so a missing key degrades to another provider.
+  const sttModel: STTModel | null =
+    getAllowedAIModel("stt", context.org.settings?.sttModel, keySource) ||
+    (IS_CLOUD && keySource.xai !== "none" ? CLOUD_MANAGED_STT_MODEL : null) ||
+    SELF_HOSTED_DEFAULT_STT_MODELS.find(
+      ([provider]) => keySource[provider] !== "none",
+    )?.[1] ||
+    null;
+
   return {
     aiEnabled,
     openAIAPIKey: includeKey ? resolvedKeys.openai.key : "",
@@ -391,6 +410,7 @@ export async function getAISettingsForOrg(
         context.org.settings?.embeddingModel,
         keySource,
       ) || DEFAULT_EMBEDDING_MODEL,
+    sttModel,
     visualEditorAIModel,
     visualEditorImageModel,
     visualEditorAIContext: (

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -387,7 +387,6 @@ export async function getAISettingsForOrg(
     : getAllowedAIModel("stt", context.org.settings?.sttModel, keySource) ||
       resolveDefaultSTTModel(
         AI_PROVIDERS.filter((p) => keySource[p] !== "none"),
-        IS_CLOUD,
       );
 
   return {

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -314,11 +314,9 @@ export async function getAISettingsForOrg(
   keySource: Record<AIProvider, AIKeySource>;
   defaultAIModel: AIModel;
   embeddingModel: EmbeddingModel;
-  // Transcription model for voice dictation, or null when no provider with a
-  // key serves one. Unlike embeddingModel this is nullable on purpose: the
-  // embedding default is only reached by an explicit "Regenerate" click that
-  // surfaces its own error, while a mic button that renders and then fails
-  // after the user has spoken is worse than no mic button.
+  // Dictation model, or null when unavailable. Nullable unlike embeddingModel
+  // because it gates a visible button: a mic that renders and then fails after
+  // the user has spoken is worse than no mic.
   sttModel: STTModel | null;
   // Resolved Visual Editor overrides — both already fall back to a
   // sensible default so callers don't need their own resolution logic.
@@ -385,15 +383,16 @@ export async function getAISettingsForOrg(
       ? CLOUD_MANAGED_IMAGE_MODEL
       : GEMINI_IMAGE_MODEL);
 
-  // Cloud prefers the managed Grok STT model; both Cloud and self-hosted then
-  // walk the provider list so a missing key degrades to another provider.
-  const sttModel: STTModel | null =
-    getAllowedAIModel("stt", context.org.settings?.sttModel, keySource) ||
-    (IS_CLOUD && keySource.xai !== "none" ? CLOUD_MANAGED_STT_MODEL : null) ||
-    SELF_HOSTED_DEFAULT_STT_MODELS.find(
-      ([provider]) => keySource[provider] !== "none",
-    )?.[1] ||
-    null;
+  // Cloud prefers the managed Grok model, then both deployments walk the
+  // provider list so a missing key degrades instead of disabling dictation.
+  const sttModel: STTModel | null = !aiEnabled
+    ? null
+    : getAllowedAIModel("stt", context.org.settings?.sttModel, keySource) ||
+      (IS_CLOUD && keySource.xai !== "none" ? CLOUD_MANAGED_STT_MODEL : null) ||
+      SELF_HOSTED_DEFAULT_STT_MODELS.find(
+        ([provider]) => keySource[provider] !== "none",
+      )?.[1] ||
+      null;
 
   return {
     aiEnabled,

--- a/packages/back-end/test/services/aiUsageCap.test.ts
+++ b/packages/back-end/test/services/aiUsageCap.test.ts
@@ -37,6 +37,7 @@ import {
   secondsUntilAICanBeUsedAgainForEmbeddings,
   secondsUntilAICanBeUsedAgainForModel,
   secondsUntilAICanBeUsedAgainForProvider,
+  secondsUntilAICanBeUsedAgainForSTT,
 } from "back-end/src/enterprise/services/ai";
 
 const mockedSettings = getAISettingsForOrg as jest.MockedFunction<
@@ -63,6 +64,7 @@ const setSettings = (settings: {
   keySource: Record<AIProvider, AIKeySource>;
   defaultAIModel?: AIModel;
   embeddingModel?: string;
+  sttModel?: string | null;
 }) => {
   mockedSettings.mockResolvedValue({
     defaultAIModel: "gpt-4o-mini",
@@ -193,5 +195,45 @@ describe("provider-exact AI usage cap", () => {
     await secondsUntilAICanBeUsedAgainForProvider(context, "xai");
 
     expect(mockedTokens).not.toHaveBeenCalled();
+  });
+});
+
+describe("dictation usage cap", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setOverCap();
+  });
+
+  it("caps dictation running on GrowthBook's managed key", async () => {
+    // Enterprise Cloud without BYOK: dictation works, on GrowthBook's key, so
+    // the org's daily cap is what limits it.
+    setSettings({
+      keySource: keySources({ openai: "env" }),
+      sttModel: "gpt-transcribe",
+    });
+
+    expect(await secondsUntilAICanBeUsedAgainForSTT(context)).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it("exempts dictation when the org pays for that provider itself", async () => {
+    setSettings({
+      keySource: keySources({ xai: "organization" }),
+      sttModel: "grok-stt-1.0",
+    });
+
+    expect(await secondsUntilAICanBeUsedAgainForSTT(context)).toBe(0);
+  });
+
+  it("caps a managed provider even when a different one is org-owned", async () => {
+    setSettings({
+      keySource: keySources({ openai: "env", xai: "organization" }),
+      sttModel: "gpt-transcribe",
+    });
+
+    expect(await secondsUntilAICanBeUsedAgainForSTT(context)).toBeGreaterThan(
+      0,
+    );
   });
 });

--- a/packages/front-end/components/GeneralSettings/AISettings.tsx
+++ b/packages/front-end/components/GeneralSettings/AISettings.tsx
@@ -18,6 +18,7 @@ import {
   getAvailableEmbeddingModelOptions,
   getAvailableImageModelOptions,
   getAvailablePromptModelOptions,
+  getAvailableSTTModelOptions,
   getModelDisplayLabel,
   GROWTHBOOK_DEFAULT_MODEL_OPTION,
   USE_DEFAULT_MODEL_OPTION,
@@ -171,6 +172,23 @@ const EmbeddingKeyWarning: React.FC<{
     <Box mt="2">
       <Callout status="warning">
         This embedding model needs a {AI_PROVIDER_META[provider].label} API key.
+        Add one under AI providers above.
+      </Callout>
+    </Box>
+  );
+};
+
+const SttKeyWarning: React.FC<{
+  sttModel: string;
+  hasKey: (provider: AIProvider) => boolean;
+}> = ({ sttModel, hasKey }) => {
+  const provider = getProviderForAIModel("stt", sttModel);
+  if (provider === null) return null;
+  if (hasKey(provider)) return null;
+  return (
+    <Box mt="2">
+      <Callout status="warning">
+        This dictation model needs a {AI_PROVIDER_META[provider].label} API key.
         Add one under AI providers above.
       </Callout>
     </Box>
@@ -432,6 +450,36 @@ export default function AISettings({
                       }
                       hasKey={hasKeyForProvider}
                     />
+                  </Box>
+                  <Box mb="6" width="100%">
+                    <Text
+                      as="label"
+                      htmlFor="sttModel"
+                      size="3"
+                      className="font-weight-semibold"
+                    >
+                      Dictation model
+                    </Text>
+                    <SelectField
+                      size="medium"
+                      id="sttModel"
+                      disabled={!canEdit}
+                      helpText="Used for voice dictation in AI chat. Supports OpenAI, xAI, and Mistral — Anthropic and Google are not available for transcription. The dictation button is hidden when none of these has a key."
+                      value={form.watch("sttModel") || ""}
+                      onChange={(v) => form.setValue("sttModel", v)}
+                      options={getAvailableSTTModelOptions(
+                        isCloud() ? availableProviders : undefined,
+                        form.watch("sttModel") || "",
+                      )}
+                    />
+                    {/* Only a chosen model can be wrong: the default resolves
+                        to a provider that already has a key, or to nothing. */}
+                    {form.watch("sttModel") && (
+                      <SttKeyWarning
+                        sttModel={form.watch("sttModel")}
+                        hasKey={hasKeyForProvider}
+                      />
+                    )}
                   </Box>
                 </>
               )}

--- a/packages/front-end/components/GeneralSettings/AISettings.tsx
+++ b/packages/front-end/components/GeneralSettings/AISettings.tsx
@@ -464,7 +464,7 @@ export default function AISettings({
                       size="medium"
                       id="sttModel"
                       disabled={!canEdit}
-                      helpText="Used for voice dictation in AI chat. Supports OpenAI, xAI, and Mistral — Anthropic and Google are not available for transcription. The dictation button is hidden when none of these has a key."
+                      helpText="Used for voice dictation in AI chat. Supports OpenAI, xAI, and Mistral. The mic button is hidden when none of them has a key."
                       value={form.watch("sttModel") || ""}
                       onChange={(v) => form.setValue("sttModel", v)}
                       options={getAvailableSTTModelOptions(
@@ -472,8 +472,8 @@ export default function AISettings({
                         form.watch("sttModel") || "",
                       )}
                     />
-                    {/* Only a chosen model can be wrong: the default resolves
-                        to a provider that already has a key, or to nothing. */}
+                    {/* Only a chosen model can be wrong — the default always
+                        resolves to a provider that has a key, or to nothing. */}
                     {form.watch("sttModel") && (
                       <SttKeyWarning
                         sttModel={form.watch("sttModel")}

--- a/packages/front-end/components/GeneralSettings/AISettings.tsx
+++ b/packages/front-end/components/GeneralSettings/AISettings.tsx
@@ -244,7 +244,7 @@ export default function AISettings({
     : null;
   // Unlike the fields above, the dictation sentinel is offered in both
   // deployments, so name the resolved model in both.
-  const sttDefault = resolveDefaultSTTModel(aiKeyProviders, isCloud());
+  const sttDefault = resolveDefaultSTTModel(aiKeyProviders);
   const sttDefaultNote = sttDefault
     ? { value: "", note: getModelDisplayLabel(sttDefault) }
     : null;

--- a/packages/front-end/components/GeneralSettings/AISettings.tsx
+++ b/packages/front-end/components/GeneralSettings/AISettings.tsx
@@ -11,6 +11,7 @@ import {
   AIProvider,
   formatAIRateLimitRetryMessage,
   getProviderForAIModel,
+  resolveDefaultSTTModel,
 } from "shared/ai";
 import {
   EMBEDDING_MODEL_OPTIONS,
@@ -225,7 +226,7 @@ export default function AISettings({
   const [loading, setLoading] = useState(false);
   const [embeddingMsg, setEmbeddingMsg] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const { hasCommercialFeature } = useUser();
+  const { hasCommercialFeature, aiKeyProviders } = useUser();
   const hasAISuggestions = hasCommercialFeature("ai-suggestions");
   const aiProviderAccess = useAIProviderKeys();
   const {
@@ -240,6 +241,12 @@ export default function AISettings({
     : null;
   const orgDefaultNote = isCloud()
     ? { value: "", note: getModelDisplayLabel(defaultAIModel) }
+    : null;
+  // Unlike the fields above, the dictation sentinel is offered in both
+  // deployments, so name the resolved model in both.
+  const sttDefault = resolveDefaultSTTModel(aiKeyProviders, isCloud());
+  const sttDefaultNote = sttDefault
+    ? { value: "", note: getModelDisplayLabel(sttDefault) }
     : null;
 
   const clearModelSettings = (keys: AIModelSettingKey[]) => {
@@ -464,13 +471,16 @@ export default function AISettings({
                       size="medium"
                       id="sttModel"
                       disabled={!canEdit}
-                      helpText="Used for voice dictation in AI chat. Supports OpenAI, xAI, and Mistral. The mic button is hidden when none of them has a key."
+                      helpText="Used for voice dictation in AI chat. Supports OpenAI, xAI, and Mistral."
                       value={form.watch("sttModel") || ""}
                       onChange={(v) => form.setValue("sttModel", v)}
                       options={getAvailableSTTModelOptions(
                         isCloud() ? availableProviders : undefined,
                         form.watch("sttModel") || "",
                       )}
+                      formatOptionLabel={(option, { context }) =>
+                        modelOptionLabel(option, context, sttDefaultNote)
+                      }
                     />
                     {/* Only a chosen model can be wrong — the default always
                         resolves to a provider that has a key, or to nothing. */}

--- a/packages/front-end/enterprise/components/AIChat/Composer/ChatComposer.module.scss
+++ b/packages/front-end/enterprise/components/AIChat/Composer/ChatComposer.module.scss
@@ -164,6 +164,15 @@
   z-index: 1;
 }
 
+// Mirrors .heroSendButton on the leading edge, so dictation is bottom-left in
+// every variant. The 40px bottom padding on .heroBox is the gutter both sit in.
+.heroDictateButton {
+  position: absolute;
+  left: 12px;
+  bottom: 12px;
+  z-index: 1;
+}
+
 // --- Buttons -----------------------------------------------------------------
 
 // `@/ui/Button` wraps its children in a Radix `<Text>` span, so an icon passed
@@ -224,4 +233,60 @@
   &:hover:not(:disabled) {
     background: var(--gray-a6);
   }
+}
+
+// --- Dictation button --------------------------------------------------------
+
+// Sits at the leading edge of the inline variants' flex row, mirroring
+// .sendButton's geometry so both align on the same baseline as the editor grows.
+.dictateButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  line-height: 0;
+  border: none;
+  border-radius: var(--radius-3);
+  background: transparent;
+  color: var(--gray-11);
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease,
+    opacity 120ms ease;
+
+  svg {
+    display: block;
+  }
+
+  &:hover:not(:disabled) {
+    background: var(--gray-a3);
+    color: var(--gray-12);
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+}
+
+// Recording. Tinted rather than pulsing: the panel already animates during a
+// turn, and a second moving thing competes with it.
+.dictateButtonActive {
+  background: var(--red-a4);
+  color: var(--red-11);
+
+  &:hover:not(:disabled) {
+    background: var(--red-a5);
+    color: var(--red-11);
+  }
+}
+
+// The row's left padding exists to inset the text from the border; the button
+// carries its own, so drop it back to the button gutter when one is present.
+.boxWithDictation {
+  padding-left: 4px;
 }

--- a/packages/front-end/enterprise/components/AIChat/Composer/ChatComposer.module.scss
+++ b/packages/front-end/enterprise/components/AIChat/Composer/ChatComposer.module.scss
@@ -157,20 +157,20 @@
   box-shadow: 0 0 0 1px var(--violet-8);
 }
 
-.heroSendButton {
+// The 40px bottom padding on .heroBox is the gutter these sit in.
+.heroSendButton,
+.heroDictateButton {
   position: absolute;
-  right: 12px;
   bottom: 12px;
   z-index: 1;
 }
 
-// Mirrors .heroSendButton on the leading edge, so dictation is bottom-left in
-// every variant. The 40px bottom padding on .heroBox is the gutter both sit in.
+.heroSendButton {
+  right: 12px;
+}
+
 .heroDictateButton {
-  position: absolute;
   left: 12px;
-  bottom: 12px;
-  z-index: 1;
 }
 
 // --- Buttons -----------------------------------------------------------------
@@ -189,7 +189,8 @@
   line-height: 0;
 }
 
-.sendButton {
+.sendButton,
+.dictateButton {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -200,11 +201,10 @@
   line-height: 0;
   border: none;
   border-radius: var(--radius-3);
-  background: var(--violet-10);
-  color: #fff;
   cursor: pointer;
   transition:
     background-color 120ms ease,
+    color 120ms ease,
     opacity 120ms ease;
 
   // The icon defaults to inline (baseline) layout, which leaves descender
@@ -214,13 +214,18 @@
     display: block;
   }
 
-  &:hover:not(:disabled) {
-    background: var(--violet-11);
-  }
-
   &:disabled {
     opacity: 0.45;
     cursor: not-allowed;
+  }
+}
+
+.sendButton {
+  background: var(--violet-10);
+  color: #fff;
+
+  &:hover:not(:disabled) {
+    background: var(--violet-11);
   }
 }
 
@@ -235,41 +240,14 @@
   }
 }
 
-// --- Dictation button --------------------------------------------------------
-
-// Sits at the leading edge of the inline variants' flex row, mirroring
-// .sendButton's geometry so both align on the same baseline as the editor grows.
+// Quiet by default — the send button is the primary action.
 .dictateButton {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  width: 30px;
-  height: 30px;
-  padding: 0;
-  line-height: 0;
-  border: none;
-  border-radius: var(--radius-3);
   background: transparent;
   color: var(--gray-11);
-  cursor: pointer;
-  transition:
-    background-color 120ms ease,
-    color 120ms ease,
-    opacity 120ms ease;
-
-  svg {
-    display: block;
-  }
 
   &:hover:not(:disabled) {
     background: var(--gray-a3);
     color: var(--gray-12);
-  }
-
-  &:disabled {
-    opacity: 0.45;
-    cursor: not-allowed;
   }
 }
 
@@ -285,8 +263,8 @@
   }
 }
 
-// The row's left padding exists to inset the text from the border; the button
-// carries its own, so drop it back to the button gutter when one is present.
+// The row's left padding insets the text from the border; the mic carries its
+// own, so drop back to the button gutter when it's present.
 .boxWithDictation {
   padding-left: 4px;
 }

--- a/packages/front-end/enterprise/components/AIChat/Composer/ChatComposer.module.scss
+++ b/packages/front-end/enterprise/components/AIChat/Composer/ChatComposer.module.scss
@@ -268,3 +268,26 @@
 .boxWithDictation {
   padding-left: 4px;
 }
+
+// Anchors the error bubble and gives the tooltip an enabled trigger to hover.
+.dictateWrapper,
+.dictateTrigger {
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+}
+
+// Floats above the composer like the suggestion list, so the flex row keeps
+// its geometry whether or not there's an error to show.
+.dictateError {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  z-index: 2;
+  width: max-content;
+  max-width: 240px;
+  padding: 6px 8px;
+  border-radius: var(--radius-3);
+  background: var(--color-panel-solid);
+  box-shadow: var(--shadow-3);
+}

--- a/packages/front-end/enterprise/components/AIChat/Composer/ChatComposer.module.scss
+++ b/packages/front-end/enterprise/components/AIChat/Composer/ChatComposer.module.scss
@@ -158,19 +158,14 @@
 }
 
 // The 40px bottom padding on .heroBox is the gutter these sit in.
-.heroSendButton,
-.heroDictateButton {
+.heroSendButton {
   position: absolute;
+  right: 12px;
   bottom: 12px;
   z-index: 1;
-}
-
-.heroSendButton {
-  right: 12px;
-}
-
-.heroDictateButton {
-  left: 12px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 // --- Buttons -----------------------------------------------------------------
@@ -263,26 +258,21 @@
   }
 }
 
-// The row's left padding insets the text from the border; the mic carries its
-// own, so drop back to the button gutter when it's present.
-.boxWithDictation {
-  padding-left: 4px;
-}
-
-// Anchors the error bubble and gives the tooltip an enabled trigger to hover.
-.dictateWrapper,
+// Gives the tooltip an enabled trigger to hover: pointer events never reach a
+// disabled button.
 .dictateTrigger {
   position: relative;
   display: inline-flex;
   flex-shrink: 0;
 }
 
-// Floats above the composer like the suggestion list, so the flex row keeps
-// its geometry whether or not there's an error to show.
+// A child of .box, positioned like SuggestionList's .popup so it clears the
+// whole composer rather than overlapping typed text. Right-aligned to sit
+// over the mic it came from.
 .dictateError {
   position: absolute;
   bottom: calc(100% + 6px);
-  left: 0;
+  right: 0;
   z-index: 2;
   width: max-content;
   max-width: 240px;

--- a/packages/front-end/enterprise/components/AIChat/Composer/ChatComposer.tsx
+++ b/packages/front-end/enterprise/components/AIChat/Composer/ChatComposer.tsx
@@ -440,8 +440,10 @@ function ChatComposer(
   }, [value, clearDictationError]);
 
   // With nothing to send, the mic takes the send button's place as the filled
-  // primary action rather than sitting next to a dead arrow.
-  const micIsPrimary = !canSend && !isLocalStream;
+  // primary action rather than sitting next to a dead arrow. Compact only:
+  // there the two are the same 30px button, so it's a swap. Wide and hero send
+  // through `@/ui/Button`, where it would also change the control's size.
+  const micIsPrimary = isCompact && !canSend && !isLocalStream;
   const dictateButton = (
     <DictationButton
       dictation={dictation}

--- a/packages/front-end/enterprise/components/AIChat/Composer/ChatComposer.tsx
+++ b/packages/front-end/enterprise/components/AIChat/Composer/ChatComposer.tsx
@@ -18,6 +18,7 @@ import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import type { AIChatMention } from "shared/ai-chat";
 import Badge from "@/ui/Badge";
 import Button from "@/ui/Button";
+import HelperText from "@/ui/HelperText";
 import {
   collectMentions,
   collectSkills,
@@ -431,14 +432,36 @@ function ChatComposer(
     </Button>
   );
 
+  // Typing dismisses a stale dictation error rather than leaving it over the
+  // field while the person retries by hand.
+  const { clearError: clearDictationError } = dictation;
+  useEffect(() => {
+    clearDictationError();
+  }, [value, clearDictationError]);
+
+  // With nothing to send, the mic takes the send button's place as the filled
+  // primary action rather than sitting next to a dead arrow.
+  const micIsPrimary = !canSend && !isLocalStream;
   const dictateButton = (
-    <DictationButton dictation={dictation} disabled={loading || disabled} />
+    <DictationButton
+      dictation={dictation}
+      disabled={loading || disabled}
+      primary={micIsPrimary}
+    />
+  );
+  // Only stand down for a mic that is actually rendered.
+  const showSendButton = !(micIsPrimary && dictation.available);
+
+  const buttons = (
+    <>
+      {dictateButton}
+      {showSendButton && sendButton}
+    </>
   );
 
   const boxClasses = [
     styles.box,
     isHero ? styles.heroBox : styles.inlineBox,
-    !isHero && dictation.available ? styles.boxWithDictation : "",
     isHero ? "" : isCompact ? styles.compactBox : styles.wideBox,
     focused
       ? isHero
@@ -470,7 +493,15 @@ function ChatComposer(
           }
         />
       )}
-      {!isHero && dictateButton}
+      {/* Anchored to the box, not to the 30px mic: `bottom: 100%` of a
+          bottom-aligned button lands inside a multi-line composer. */}
+      {dictation.error && (
+        <div className={styles.dictateError} role="status" aria-live="polite">
+          <HelperText status="error" size="sm">
+            {dictation.error}
+          </HelperText>
+        </div>
+      )}
       <EditorContent
         editor={editor}
         className={`${styles.editor}${loading || disabled ? ` ${styles.readOnly}` : ""}`}
@@ -479,12 +510,9 @@ function ChatComposer(
         onBlur={handleBlur}
       />
       {isHero ? (
-        <>
-          <div className={styles.heroDictateButton}>{dictateButton}</div>
-          <div className={styles.heroSendButton}>{sendButton}</div>
-        </>
+        <div className={styles.heroSendButton}>{buttons}</div>
       ) : (
-        sendButton
+        buttons
       )}
     </div>
   );

--- a/packages/front-end/enterprise/components/AIChat/Composer/ChatComposer.tsx
+++ b/packages/front-end/enterprise/components/AIChat/Composer/ChatComposer.tsx
@@ -382,9 +382,16 @@ function ChatComposer(
     useCallback(
       (text: string) => {
         if (!editor) return;
-        const needsSpace = /\S$/.test(editorToText(editor));
-        editor.commands.insertContent(needsSpace ? ` ${text}` : text);
-        editor.commands.focus("end");
+        // Space off the character before the cursor, not the end of the doc —
+        // dictation can land mid-message. insertContent leaves the cursor
+        // after the inserted text, so don't move it.
+        const { from } = editor.state.selection;
+        const before = editor.state.doc.textBetween(
+          Math.max(0, from - 1),
+          from,
+        );
+        editor.commands.insertContent(/\S/.test(before) ? ` ${text}` : text);
+        editor.commands.focus();
       },
       [editor],
     ),

--- a/packages/front-end/enterprise/components/AIChat/Composer/ChatComposer.tsx
+++ b/packages/front-end/enterprise/components/AIChat/Composer/ChatComposer.tsx
@@ -43,6 +43,8 @@ import TokenHoverCard, {
   readHoveredToken,
   type HoveredToken,
 } from "./TokenHoverCard";
+import DictationButton from "./DictationButton";
+import { useDictation } from "./useDictation";
 import SuggestionList, {
   SUGGESTION_LISTBOX_ID,
   suggestionOptionId,
@@ -374,6 +376,20 @@ function ChatComposer(
     onSend(readSubmission(editor.state.doc));
   }, [editor, onSend]);
 
+  // Dictated text lands at the cursor like typing would, so it can be edited
+  // before sending rather than submitted straight from the mic.
+  const dictation = useDictation(
+    useCallback(
+      (text: string) => {
+        if (!editor) return;
+        const needsSpace = /\S$/.test(editorToText(editor));
+        editor.commands.insertContent(needsSpace ? ` ${text}` : text);
+        editor.commands.focus("end");
+      },
+      [editor],
+    ),
+  );
+
   const canSend = value.trim().length > 0 && !loading && !disabled;
   const isCompact = variant === "compact";
   const isHero = variant === "hero";
@@ -408,9 +424,14 @@ function ChatComposer(
     </Button>
   );
 
+  const dictateButton = (
+    <DictationButton dictation={dictation} disabled={loading || disabled} />
+  );
+
   const boxClasses = [
     styles.box,
     isHero ? styles.heroBox : styles.inlineBox,
+    !isHero && dictation.available ? styles.boxWithDictation : "",
     isHero ? "" : isCompact ? styles.compactBox : styles.wideBox,
     focused
       ? isHero
@@ -442,6 +463,7 @@ function ChatComposer(
           }
         />
       )}
+      {!isHero && dictateButton}
       <EditorContent
         editor={editor}
         className={`${styles.editor}${loading || disabled ? ` ${styles.readOnly}` : ""}`}
@@ -450,7 +472,10 @@ function ChatComposer(
         onBlur={handleBlur}
       />
       {isHero ? (
-        <div className={styles.heroSendButton}>{sendButton}</div>
+        <>
+          <div className={styles.heroDictateButton}>{dictateButton}</div>
+          <div className={styles.heroSendButton}>{sendButton}</div>
+        </>
       ) : (
         sendButton
       )}

--- a/packages/front-end/enterprise/components/AIChat/Composer/DictationButton.tsx
+++ b/packages/front-end/enterprise/components/AIChat/Composer/DictationButton.tsx
@@ -1,4 +1,9 @@
-import { PiMicrophone, PiMicrophoneSlash, PiSpinnerGap } from "react-icons/pi";
+import {
+  PiMicrophone,
+  PiMicrophoneSlash,
+  PiSpinnerGap,
+  PiStop,
+} from "react-icons/pi";
 import Tooltip from "@/ui/Tooltip";
 import aiChatStyles from "@/enterprise/components/AIChat/AIChatPrimitives.module.scss";
 import type { Dictation } from "./useDictation";
@@ -23,11 +28,18 @@ export default function DictationButton({
       ? "Transcribing…"
       : "Dictate a message";
 
+  // Recording gets its own glyph, not just the red tint: state communicated by
+  // color alone fails WCAG 1.4.1, and this control can hold the mic open for
+  // five minutes. PiStop is already this composer's vocabulary for "stop", and
+  // can't collide with the send button's stop state — the mic is disabled
+  // while a turn is streaming.
   const Icon = error
     ? PiMicrophoneSlash
     : transcribing
       ? PiSpinnerGap
-      : PiMicrophone;
+      : recording
+        ? PiStop
+        : PiMicrophone;
 
   return (
     <Tooltip content={label}>

--- a/packages/front-end/enterprise/components/AIChat/Composer/DictationButton.tsx
+++ b/packages/front-end/enterprise/components/AIChat/Composer/DictationButton.tsx
@@ -1,0 +1,48 @@
+import { PiMicrophone, PiMicrophoneSlash, PiSpinnerGap } from "react-icons/pi";
+import Tooltip from "@/ui/Tooltip";
+import type { Dictation } from "./useDictation";
+import styles from "./ChatComposer.module.scss";
+
+/**
+ * Mic toggle for the composer. Renders nothing when the org has no
+ * transcription model available — see useDictation.
+ */
+export default function DictationButton({
+  dictation,
+  disabled = false,
+}: {
+  dictation: Dictation;
+  disabled?: boolean;
+}) {
+  const { available, recording, transcribing, error, toggle } = dictation;
+  if (!available) return null;
+
+  const label = error
+    ? error
+    : recording
+      ? "Stop dictating"
+      : transcribing
+        ? "Transcribing…"
+        : "Dictate a message";
+
+  const Icon = error
+    ? PiMicrophoneSlash
+    : transcribing
+      ? PiSpinnerGap
+      : PiMicrophone;
+
+  return (
+    <Tooltip content={label}>
+      <button
+        type="button"
+        className={`${styles.dictateButton}${recording ? ` ${styles.dictateButtonActive}` : ""}`}
+        onClick={toggle}
+        disabled={disabled || transcribing}
+        aria-label={label}
+        aria-pressed={recording}
+      >
+        <Icon size={16} />
+      </button>
+    </Tooltip>
+  );
+}

--- a/packages/front-end/enterprise/components/AIChat/Composer/DictationButton.tsx
+++ b/packages/front-end/enterprise/components/AIChat/Composer/DictationButton.tsx
@@ -1,5 +1,4 @@
 import { PiMicrophone, PiMicrophoneSlash, PiSpinnerGap } from "react-icons/pi";
-import HelperText from "@/ui/HelperText";
 import Tooltip from "@/ui/Tooltip";
 import aiChatStyles from "@/enterprise/components/AIChat/AIChatPrimitives.module.scss";
 import type { Dictation } from "./useDictation";
@@ -9,9 +8,12 @@ import styles from "./ChatComposer.module.scss";
 export default function DictationButton({
   dictation: { available, recording, transcribing, error, toggle },
   disabled = false,
+  primary = false,
 }: {
   dictation: Dictation;
   disabled?: boolean;
+  /** Takes the send button's filled treatment when there's nothing to send. */
+  primary?: boolean;
 }) {
   if (!available) return null;
 
@@ -28,39 +30,32 @@ export default function DictationButton({
       : PiMicrophone;
 
   return (
-    <span className={styles.dictateWrapper}>
-      {/* A slash on the icon alone reads as "unavailable" rather than as a
-          recoverable error, and nobody hovers a control they didn't click. */}
-      {error && (
-        <div className={styles.dictateError} role="status" aria-live="polite">
-          <HelperText status="error" size="sm">
-            {error}
-          </HelperText>
-        </div>
-      )}
-      <Tooltip content={label}>
-        {/* Radix tooltips need an enabled trigger — pointer events never reach
-            a disabled button, so the wrapper is what gets hovered. */}
-        <span className={styles.dictateTrigger}>
-          <button
-            type="button"
-            className={`${styles.dictateButton}${recording ? ` ${styles.dictateButtonActive}` : ""}`}
-            onClick={toggle}
-            disabled={disabled || transcribing}
-            aria-label={label}
-            aria-pressed={recording}
-            aria-busy={transcribing}
-          >
-            {transcribing ? (
-              <span className={aiChatStyles.spinIcon}>
-                <Icon size={16} />
-              </span>
-            ) : (
+    <Tooltip content={label}>
+      {/* Radix tooltips need an enabled trigger — pointer events never reach a
+          disabled button, so the wrapper is what gets hovered. */}
+      <span className={styles.dictateTrigger}>
+        <button
+          type="button"
+          // The two buttons already share their geometry, so the filled
+          // treatment is just the send button's own class.
+          className={`${primary ? styles.sendButton : styles.dictateButton}${
+            recording ? ` ${styles.dictateButtonActive}` : ""
+          }`}
+          onClick={toggle}
+          disabled={disabled || transcribing}
+          aria-label={label}
+          aria-pressed={recording}
+          aria-busy={transcribing}
+        >
+          {transcribing ? (
+            <span className={aiChatStyles.spinIcon}>
               <Icon size={16} />
-            )}
-          </button>
-        </span>
-      </Tooltip>
-    </span>
+            </span>
+          ) : (
+            <Icon size={16} />
+          )}
+        </button>
+      </span>
+    </Tooltip>
   );
 }

--- a/packages/front-end/enterprise/components/AIChat/Composer/DictationButton.tsx
+++ b/packages/front-end/enterprise/components/AIChat/Composer/DictationButton.tsx
@@ -1,5 +1,7 @@
 import { PiMicrophone, PiMicrophoneSlash, PiSpinnerGap } from "react-icons/pi";
+import HelperText from "@/ui/HelperText";
 import Tooltip from "@/ui/Tooltip";
+import aiChatStyles from "@/enterprise/components/AIChat/AIChatPrimitives.module.scss";
 import type { Dictation } from "./useDictation";
 import styles from "./ChatComposer.module.scss";
 
@@ -13,14 +15,11 @@ export default function DictationButton({
 }) {
   if (!available) return null;
 
-  // The tooltip doubles as the error surface, paired with the slashed icon.
-  const label =
-    error ??
-    (recording
-      ? "Stop dictating"
-      : transcribing
-        ? "Transcribing…"
-        : "Dictate a message");
+  const label = recording
+    ? "Stop dictating"
+    : transcribing
+      ? "Transcribing…"
+      : "Dictate a message";
 
   const Icon = error
     ? PiMicrophoneSlash
@@ -29,17 +28,39 @@ export default function DictationButton({
       : PiMicrophone;
 
   return (
-    <Tooltip content={label}>
-      <button
-        type="button"
-        className={`${styles.dictateButton}${recording ? ` ${styles.dictateButtonActive}` : ""}`}
-        onClick={toggle}
-        disabled={disabled || transcribing}
-        aria-label={label}
-        aria-pressed={recording}
-      >
-        <Icon size={16} />
-      </button>
-    </Tooltip>
+    <span className={styles.dictateWrapper}>
+      {/* A slash on the icon alone reads as "unavailable" rather than as a
+          recoverable error, and nobody hovers a control they didn't click. */}
+      {error && (
+        <div className={styles.dictateError} role="status" aria-live="polite">
+          <HelperText status="error" size="sm">
+            {error}
+          </HelperText>
+        </div>
+      )}
+      <Tooltip content={label}>
+        {/* Radix tooltips need an enabled trigger — pointer events never reach
+            a disabled button, so the wrapper is what gets hovered. */}
+        <span className={styles.dictateTrigger}>
+          <button
+            type="button"
+            className={`${styles.dictateButton}${recording ? ` ${styles.dictateButtonActive}` : ""}`}
+            onClick={toggle}
+            disabled={disabled || transcribing}
+            aria-label={label}
+            aria-pressed={recording}
+            aria-busy={transcribing}
+          >
+            {transcribing ? (
+              <span className={aiChatStyles.spinIcon}>
+                <Icon size={16} />
+              </span>
+            ) : (
+              <Icon size={16} />
+            )}
+          </button>
+        </span>
+      </Tooltip>
+    </span>
   );
 }

--- a/packages/front-end/enterprise/components/AIChat/Composer/DictationButton.tsx
+++ b/packages/front-end/enterprise/components/AIChat/Composer/DictationButton.tsx
@@ -28,11 +28,7 @@ export default function DictationButton({
       ? "Transcribing…"
       : "Dictate a message";
 
-  // Recording gets its own glyph, not just the red tint: state communicated by
-  // color alone fails WCAG 1.4.1, and this control can hold the mic open for
-  // five minutes. PiStop is already this composer's vocabulary for "stop", and
-  // can't collide with the send button's stop state — the mic is disabled
-  // while a turn is streaming.
+  // Recording gets its own glyph, not just red: color-only state fails WCAG 1.4.1.
   const Icon = error
     ? PiMicrophoneSlash
     : transcribing

--- a/packages/front-end/enterprise/components/AIChat/Composer/DictationButton.tsx
+++ b/packages/front-end/enterprise/components/AIChat/Composer/DictationButton.tsx
@@ -3,27 +3,24 @@ import Tooltip from "@/ui/Tooltip";
 import type { Dictation } from "./useDictation";
 import styles from "./ChatComposer.module.scss";
 
-/**
- * Mic toggle for the composer. Renders nothing when the org has no
- * transcription model available — see useDictation.
- */
+/** Mic toggle. Renders nothing when dictation isn't available to the org. */
 export default function DictationButton({
-  dictation,
+  dictation: { available, recording, transcribing, error, toggle },
   disabled = false,
 }: {
   dictation: Dictation;
   disabled?: boolean;
 }) {
-  const { available, recording, transcribing, error, toggle } = dictation;
   if (!available) return null;
 
-  const label = error
-    ? error
-    : recording
+  // The tooltip doubles as the error surface, paired with the slashed icon.
+  const label =
+    error ??
+    (recording
       ? "Stop dictating"
       : transcribing
         ? "Transcribing…"
-        : "Dictate a message";
+        : "Dictate a message");
 
   const Icon = error
     ? PiMicrophoneSlash

--- a/packages/front-end/enterprise/components/AIChat/Composer/useDictation.ts
+++ b/packages/front-end/enterprise/components/AIChat/Composer/useDictation.ts
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAuth } from "@/services/auth";
+import { useUser } from "@/services/UserContext";
+import { useAISettings } from "@/hooks/useOrgSettings";
+
+// Containers in preference order. xAI's STT doesn't list WebM among its
+// accepted formats (though it does list MKV, which WebM is a subset of), so
+// prefer the containers every provider names before falling back to it.
+// Safari produces mp4, Chrome produces webm.
+const PREFERRED_MIME_TYPES = [
+  "audio/mp4",
+  "audio/ogg;codecs=opus",
+  "audio/webm;codecs=opus",
+  "audio/webm",
+];
+
+// A forgotten open mic is a memory and a billing problem, so cap the clip.
+const MAX_RECORDING_MS = 5 * 60 * 1000;
+
+function pickMimeType(): string | null {
+  if (typeof MediaRecorder === "undefined") return null;
+  return (
+    PREFERRED_MIME_TYPES.find((type) => MediaRecorder.isTypeSupported(type)) ??
+    null
+  );
+}
+
+export interface Dictation {
+  /** False when the org has no transcription model or the browser can't record. */
+  available: boolean;
+  recording: boolean;
+  transcribing: boolean;
+  error: string | null;
+  toggle: () => void;
+}
+
+/**
+ * Record a clip from the microphone and hand the transcript to `onTranscript`.
+ *
+ * `sttModel` is resolved server-side and arrives on the org payload, so this
+ * doesn't re-derive availability from the provider key list — the settings
+ * dropdown only filters by key on Cloud, and a second guess here could
+ * disagree with what the transcribe route actually does.
+ */
+export function useDictation(onTranscript: (text: string) => void): Dictation {
+  const { apiCall } = useAuth();
+  const { sttModel } = useUser();
+  const { aiEnabled } = useAISettings();
+
+  // Set after mount: MediaRecorder doesn't exist during SSR, and deciding
+  // during render would make the server and first client render disagree.
+  const [canRecord, setCanRecord] = useState(false);
+  useEffect(() => setCanRecord(!!pickMimeType()), []);
+
+  const [recording, setRecording] = useState(false);
+  const [transcribing, setTranscribing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const timeoutRef = useRef<number | null>(null);
+  // Read in the recorder's async callbacks, which outlive a render.
+  const onTranscriptRef = useRef(onTranscript);
+  onTranscriptRef.current = onTranscript;
+
+  const stopTracks = useCallback(() => {
+    recorderRef.current?.stream.getTracks().forEach((t) => t.stop());
+    recorderRef.current = null;
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  // Releasing the mic on unmount matters — the browser shows a recording
+  // indicator for as long as the track is live.
+  useEffect(() => stopTracks, [stopTracks]);
+
+  const stop = useCallback(() => {
+    recorderRef.current?.stop();
+    setRecording(false);
+  }, []);
+
+  const start = useCallback(async () => {
+    setError(null);
+    const mimeType = pickMimeType();
+    if (!mimeType) {
+      setError("This browser can't record audio.");
+      return;
+    }
+
+    let stream: MediaStream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch {
+      // Denied, dismissed, or no input device — all the same to the user.
+      setError("Microphone access was blocked.");
+      return;
+    }
+
+    const recorder = new MediaRecorder(stream, { mimeType });
+    recorderRef.current = recorder;
+    const chunks: Blob[] = [];
+    recorder.ondataavailable = (e) => {
+      if (e.data.size) chunks.push(e.data);
+    };
+
+    recorder.onstop = async () => {
+      stopTracks();
+      const audio = new Blob(chunks, { type: mimeType });
+      if (!audio.size) return;
+
+      setTranscribing(true);
+      try {
+        const res = await apiCall<{ text: string }>("/ai/transcribe", {
+          method: "POST",
+          body: audio,
+          headers: { "Content-Type": mimeType },
+        });
+        const text = res?.text?.trim();
+        if (text) onTranscriptRef.current(text);
+        else setError("Nothing was transcribed. Try again.");
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Transcription failed.");
+      } finally {
+        setTranscribing(false);
+      }
+    };
+
+    recorder.start();
+    setRecording(true);
+    timeoutRef.current = window.setTimeout(stop, MAX_RECORDING_MS);
+  }, [apiCall, stop, stopTracks]);
+
+  return {
+    available: !!sttModel && aiEnabled && canRecord,
+    recording,
+    transcribing,
+    error,
+    toggle: () => (recording ? stop() : start()),
+  };
+}

--- a/packages/front-end/enterprise/components/AIChat/Composer/useDictation.ts
+++ b/packages/front-end/enterprise/components/AIChat/Composer/useDictation.ts
@@ -2,10 +2,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useAuth } from "@/services/auth";
 import { useUser } from "@/services/UserContext";
 
-// Containers in preference order, narrowed to what every transcription
-// endpoint accepts. OpenAI's list is the binding one (mp3, mp4, mpeg, mpga,
-// m4a, wav, webm) — notably it rejects ogg, so offering ogg/opus guaranteed a
-// failure on Firefox. Safari records mp4; Chrome and Firefox record webm.
+// Narrowed to what every transcription endpoint accepts. OpenAI's list is the
+// binding one, and it rejects ogg — offering ogg/opus failed on Firefox.
 const MIME_TYPES = ["audio/mp4", "audio/webm;codecs=opus"];
 
 // A forgotten open mic is a memory and a billing problem.
@@ -29,30 +27,24 @@ export interface Dictation {
 /** Record a clip and hand the transcript to `onTranscript`. */
 export function useDictation(onTranscript: (text: string) => void): Dictation {
   const { apiCall } = useAuth();
-  // Resolved server-side, and already null when AI is off or no provider with
-  // a key serves transcription — so there is nothing to re-derive here.
+  // Already null when AI is off or no provider with a key serves transcription.
   const { sttModel } = useUser();
 
-  // Set after mount: MediaRecorder doesn't exist during SSR, and deciding
-  // during render would make the server and first client render disagree.
-  const [canRecord, setCanRecord] = useState(false);
-  useEffect(() => setCanRecord(!!pickMimeType()), []);
-
-  const [recording, setRecording] = useState(false);
-  const [transcribing, setTranscribing] = useState(false);
+  const [status, setStatus] = useState<"idle" | "recording" | "transcribing">(
+    "idle",
+  );
   const [error, setError] = useState<string | null>(null);
 
   const recorderRef = useRef<MediaRecorder | null>(null);
   const timeoutRef = useRef<number | null>(null);
-  // Set before awaiting the permission prompt, so a double-click can't open a
-  // second stream that orphans the first and leaves the mic live.
-  const startingRef = useRef(false);
-  const unmountedRef = useRef(false);
-  // Read inside the recorder's callbacks, which outlive a render.
-  const onTranscriptRef = useRef(onTranscript);
-  onTranscriptRef.current = onTranscript;
+  // Non-null while a permission prompt is open. Doubles as the re-entrancy
+  // guard (a double-click would otherwise orphan the first stream) and the
+  // cancel signal, since release() aborts it.
+  const startAbortRef = useRef<AbortController | null>(null);
 
   const release = useCallback(() => {
+    startAbortRef.current?.abort();
+    startAbortRef.current = null;
     recorderRef.current?.stream.getTracks().forEach((t) => t.stop());
     recorderRef.current = null;
     if (timeoutRef.current !== null) window.clearTimeout(timeoutRef.current);
@@ -60,27 +52,17 @@ export function useDictation(onTranscript: (text: string) => void): Dictation {
   }, []);
 
   // The browser shows a recording indicator for as long as a track is live.
-  // Reset on mount too, or a StrictMode double-mount leaves the flag set and
-  // every later start() bails out.
-  useEffect(() => {
-    unmountedRef.current = false;
-    return () => {
-      unmountedRef.current = true;
-      release();
-    };
-  }, [release]);
+  useEffect(() => release, [release]);
 
-  // setState bails when the value is unchanged, so calling this per keystroke
-  // costs nothing.
   const clearError = useCallback(() => setError(null), []);
 
   const stop = useCallback(() => {
     recorderRef.current?.stop();
-    setRecording(false);
+    setStatus("idle");
   }, []);
 
   const start = useCallback(async () => {
-    if (startingRef.current || recorderRef.current) return;
+    if (startAbortRef.current || recorderRef.current) return;
     setError(null);
     const mimeType = pickMimeType();
     if (!mimeType) {
@@ -88,7 +70,8 @@ export function useDictation(onTranscript: (text: string) => void): Dictation {
       return;
     }
 
-    startingRef.current = true;
+    const abort = new AbortController();
+    startAbortRef.current = abort;
     let stream: MediaStream;
     try {
       stream = await navigator.mediaDevices.getUserMedia({ audio: true });
@@ -97,11 +80,12 @@ export function useDictation(onTranscript: (text: string) => void): Dictation {
       setError("Microphone access was blocked.");
       return;
     } finally {
-      startingRef.current = false;
+      // Identity-checked: release() may already have cleared it for a newer start.
+      if (startAbortRef.current === abort) startAbortRef.current = null;
     }
 
     // The prompt can outlive the component; don't start a mic nobody owns.
-    if (unmountedRef.current) {
+    if (abort.signal.aborted) {
       stream.getTracks().forEach((t) => t.stop());
       return;
     }
@@ -118,7 +102,7 @@ export function useDictation(onTranscript: (text: string) => void): Dictation {
       const audio = new Blob(chunks, { type: mimeType });
       if (!audio.size) return;
 
-      setTranscribing(true);
+      setStatus("transcribing");
       try {
         const res = await apiCall<{ text: string }>("/ai/transcribe", {
           method: "POST",
@@ -126,26 +110,26 @@ export function useDictation(onTranscript: (text: string) => void): Dictation {
           headers: { "Content-Type": mimeType },
         });
         const text = res?.text?.trim();
-        if (text) onTranscriptRef.current(text);
+        if (text) onTranscript(text);
         else setError("Nothing was transcribed. Try again.");
       } catch (e) {
         setError(e instanceof Error ? e.message : "Transcription failed.");
       } finally {
-        setTranscribing(false);
+        setStatus("idle");
       }
     };
 
     recorder.start();
-    setRecording(true);
+    setStatus("recording");
     timeoutRef.current = window.setTimeout(stop, MAX_RECORDING_MS);
-  }, [apiCall, release, stop]);
+  }, [apiCall, onTranscript, release, stop]);
 
   return {
-    available: !!sttModel && canRecord,
-    recording,
-    transcribing,
+    available: !!sttModel && !!pickMimeType(),
+    recording: status === "recording",
+    transcribing: status === "transcribing",
     error,
-    toggle: () => (recording ? stop() : start()),
+    toggle: () => (status === "recording" ? stop() : start()),
     clearError,
   };
 }

--- a/packages/front-end/enterprise/components/AIChat/Composer/useDictation.ts
+++ b/packages/front-end/enterprise/components/AIChat/Composer/useDictation.ts
@@ -1,32 +1,25 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAuth } from "@/services/auth";
 import { useUser } from "@/services/UserContext";
-import { useAISettings } from "@/hooks/useOrgSettings";
 
 // Containers in preference order. xAI's STT doesn't list WebM among its
-// accepted formats (though it does list MKV, which WebM is a subset of), so
-// prefer the containers every provider names before falling back to it.
-// Safari produces mp4, Chrome produces webm.
-const PREFERRED_MIME_TYPES = [
+// accepted formats, so try what every provider names before falling back to
+// it. Safari records mp4, Chrome records webm.
+const MIME_TYPES = [
   "audio/mp4",
   "audio/ogg;codecs=opus",
   "audio/webm;codecs=opus",
-  "audio/webm",
 ];
 
-// A forgotten open mic is a memory and a billing problem, so cap the clip.
+// A forgotten open mic is a memory and a billing problem.
 const MAX_RECORDING_MS = 5 * 60 * 1000;
 
-function pickMimeType(): string | null {
-  if (typeof MediaRecorder === "undefined") return null;
-  return (
-    PREFERRED_MIME_TYPES.find((type) => MediaRecorder.isTypeSupported(type)) ??
-    null
-  );
-}
+const pickMimeType = () =>
+  typeof MediaRecorder === "undefined"
+    ? null
+    : (MIME_TYPES.find((t) => MediaRecorder.isTypeSupported(t)) ?? null);
 
 export interface Dictation {
-  /** False when the org has no transcription model or the browser can't record. */
   available: boolean;
   recording: boolean;
   transcribing: boolean;
@@ -34,18 +27,12 @@ export interface Dictation {
   toggle: () => void;
 }
 
-/**
- * Record a clip from the microphone and hand the transcript to `onTranscript`.
- *
- * `sttModel` is resolved server-side and arrives on the org payload, so this
- * doesn't re-derive availability from the provider key list — the settings
- * dropdown only filters by key on Cloud, and a second guess here could
- * disagree with what the transcribe route actually does.
- */
+/** Record a clip and hand the transcript to `onTranscript`. */
 export function useDictation(onTranscript: (text: string) => void): Dictation {
   const { apiCall } = useAuth();
+  // Resolved server-side, and already null when AI is off or no provider with
+  // a key serves transcription — so there is nothing to re-derive here.
   const { sttModel } = useUser();
-  const { aiEnabled } = useAISettings();
 
   // Set after mount: MediaRecorder doesn't exist during SSR, and deciding
   // during render would make the server and first client render disagree.
@@ -58,22 +45,19 @@ export function useDictation(onTranscript: (text: string) => void): Dictation {
 
   const recorderRef = useRef<MediaRecorder | null>(null);
   const timeoutRef = useRef<number | null>(null);
-  // Read in the recorder's async callbacks, which outlive a render.
+  // Read inside the recorder's callbacks, which outlive a render.
   const onTranscriptRef = useRef(onTranscript);
   onTranscriptRef.current = onTranscript;
 
-  const stopTracks = useCallback(() => {
+  const release = useCallback(() => {
     recorderRef.current?.stream.getTracks().forEach((t) => t.stop());
     recorderRef.current = null;
-    if (timeoutRef.current !== null) {
-      window.clearTimeout(timeoutRef.current);
-      timeoutRef.current = null;
-    }
+    if (timeoutRef.current !== null) window.clearTimeout(timeoutRef.current);
+    timeoutRef.current = null;
   }, []);
 
-  // Releasing the mic on unmount matters — the browser shows a recording
-  // indicator for as long as the track is live.
-  useEffect(() => stopTracks, [stopTracks]);
+  // The browser shows a recording indicator for as long as a track is live.
+  useEffect(() => release, [release]);
 
   const stop = useCallback(() => {
     recorderRef.current?.stop();
@@ -92,7 +76,7 @@ export function useDictation(onTranscript: (text: string) => void): Dictation {
     try {
       stream = await navigator.mediaDevices.getUserMedia({ audio: true });
     } catch {
-      // Denied, dismissed, or no input device — all the same to the user.
+      // Denied, dismissed, or no input device — same outcome to the user.
       setError("Microphone access was blocked.");
       return;
     }
@@ -105,7 +89,7 @@ export function useDictation(onTranscript: (text: string) => void): Dictation {
     };
 
     recorder.onstop = async () => {
-      stopTracks();
+      release();
       const audio = new Blob(chunks, { type: mimeType });
       if (!audio.size) return;
 
@@ -129,10 +113,10 @@ export function useDictation(onTranscript: (text: string) => void): Dictation {
     recorder.start();
     setRecording(true);
     timeoutRef.current = window.setTimeout(stop, MAX_RECORDING_MS);
-  }, [apiCall, stop, stopTracks]);
+  }, [apiCall, release, stop]);
 
   return {
-    available: !!sttModel && aiEnabled && canRecord,
+    available: !!sttModel && canRecord,
     recording,
     transcribing,
     error,

--- a/packages/front-end/enterprise/components/AIChat/Composer/useDictation.ts
+++ b/packages/front-end/enterprise/components/AIChat/Composer/useDictation.ts
@@ -2,14 +2,11 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useAuth } from "@/services/auth";
 import { useUser } from "@/services/UserContext";
 
-// Containers in preference order. xAI's STT doesn't list WebM among its
-// accepted formats, so try what every provider names before falling back to
-// it. Safari records mp4, Chrome records webm.
-const MIME_TYPES = [
-  "audio/mp4",
-  "audio/ogg;codecs=opus",
-  "audio/webm;codecs=opus",
-];
+// Containers in preference order, narrowed to what every transcription
+// endpoint accepts. OpenAI's list is the binding one (mp3, mp4, mpeg, mpga,
+// m4a, wav, webm) — notably it rejects ogg, so offering ogg/opus guaranteed a
+// failure on Firefox. Safari records mp4; Chrome and Firefox record webm.
+const MIME_TYPES = ["audio/mp4", "audio/webm;codecs=opus"];
 
 // A forgotten open mic is a memory and a billing problem.
 const MAX_RECORDING_MS = 5 * 60 * 1000;
@@ -45,6 +42,10 @@ export function useDictation(onTranscript: (text: string) => void): Dictation {
 
   const recorderRef = useRef<MediaRecorder | null>(null);
   const timeoutRef = useRef<number | null>(null);
+  // Set before awaiting the permission prompt, so a double-click can't open a
+  // second stream that orphans the first and leaves the mic live.
+  const startingRef = useRef(false);
+  const unmountedRef = useRef(false);
   // Read inside the recorder's callbacks, which outlive a render.
   const onTranscriptRef = useRef(onTranscript);
   onTranscriptRef.current = onTranscript;
@@ -57,7 +58,15 @@ export function useDictation(onTranscript: (text: string) => void): Dictation {
   }, []);
 
   // The browser shows a recording indicator for as long as a track is live.
-  useEffect(() => release, [release]);
+  // Reset on mount too, or a StrictMode double-mount leaves the flag set and
+  // every later start() bails out.
+  useEffect(() => {
+    unmountedRef.current = false;
+    return () => {
+      unmountedRef.current = true;
+      release();
+    };
+  }, [release]);
 
   const stop = useCallback(() => {
     recorderRef.current?.stop();
@@ -65,6 +74,7 @@ export function useDictation(onTranscript: (text: string) => void): Dictation {
   }, []);
 
   const start = useCallback(async () => {
+    if (startingRef.current || recorderRef.current) return;
     setError(null);
     const mimeType = pickMimeType();
     if (!mimeType) {
@@ -72,12 +82,21 @@ export function useDictation(onTranscript: (text: string) => void): Dictation {
       return;
     }
 
+    startingRef.current = true;
     let stream: MediaStream;
     try {
       stream = await navigator.mediaDevices.getUserMedia({ audio: true });
     } catch {
       // Denied, dismissed, or no input device — same outcome to the user.
       setError("Microphone access was blocked.");
+      return;
+    } finally {
+      startingRef.current = false;
+    }
+
+    // The prompt can outlive the component; don't start a mic nobody owns.
+    if (unmountedRef.current) {
+      stream.getTracks().forEach((t) => t.stop());
       return;
     }
 

--- a/packages/front-end/enterprise/components/AIChat/Composer/useDictation.ts
+++ b/packages/front-end/enterprise/components/AIChat/Composer/useDictation.ts
@@ -22,6 +22,8 @@ export interface Dictation {
   transcribing: boolean;
   error: string | null;
   toggle: () => void;
+  /** Called on editor input so a failed attempt doesn't linger over a retry. */
+  clearError: () => void;
 }
 
 /** Record a clip and hand the transcript to `onTranscript`. */
@@ -67,6 +69,10 @@ export function useDictation(onTranscript: (text: string) => void): Dictation {
       release();
     };
   }, [release]);
+
+  // setState bails when the value is unchanged, so calling this per keystroke
+  // costs nothing.
+  const clearError = useCallback(() => setError(null), []);
 
   const stop = useCallback(() => {
     recorderRef.current?.stop();
@@ -140,5 +146,6 @@ export function useDictation(onTranscript: (text: string) => void): Dictation {
     transcribing,
     error,
     toggle: () => (recording ? stop() : start()),
+    clearError,
   };
 }

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -215,6 +215,9 @@ const GeneralSettingsPage = (): React.ReactElement => {
       defaultAIModel:
         settings.defaultAIModel || (isCloud() ? undefined : "gpt-4o-mini"),
       embeddingModel: settings.embeddingModel || "text-embedding-ada-002",
+      // Left unset rather than seeded: the resolved model depends on which
+      // provider keys exist, so there is no correct value to pre-fill.
+      sttModel: settings.sttModel,
       visualEditorAIModel: settings.visualEditorAIModel,
       visualEditorImageModel: settings.visualEditorImageModel || "",
       visualEditorAIContext: settings.visualEditorAIContext || "",
@@ -285,6 +288,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
     aiEnabled: form.watch("aiEnabled"),
     defaultAIModel: form.watch("defaultAIModel"),
     embeddingModel: form.watch("embeddingModel"),
+    sttModel: form.watch("sttModel") || undefined,
     visualEditorAIModel: form.watch("visualEditorAIModel"),
     visualEditorImageModel: form.watch("visualEditorImageModel"),
     visualEditorAIContext: form.watch("visualEditorAIContext") || undefined,

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -215,8 +215,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
       defaultAIModel:
         settings.defaultAIModel || (isCloud() ? undefined : "gpt-4o-mini"),
       embeddingModel: settings.embeddingModel || "text-embedding-ada-002",
-      // Left unset rather than seeded: the resolved model depends on which
-      // provider keys exist, so there is no correct value to pre-fill.
+      // Unset, not seeded: the resolved model depends on which keys exist.
       sttModel: settings.sttModel,
       visualEditorAIModel: settings.visualEditorAIModel,
       visualEditorImageModel: settings.visualEditorImageModel || "",

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -129,8 +129,7 @@ export interface UserContextValue {
   // AI providers with a usable API key, from the org's own stored keys or the
   // host's environment variables.
   aiKeyProviders: AIProvider[];
-  // Resolved transcription model for voice dictation, or null when no provider
-  // with a key serves one. Null is what hides the dictation button.
+  // Resolved dictation model, null when unavailable. Hides the mic button.
   sttModel: STTModel | null;
   seatsInUse: number;
   roles: Role[];

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -39,7 +39,7 @@ import { Permissions, userHasPermission } from "shared/permissions";
 import { getValidDate } from "shared/dates";
 import sha256 from "crypto-js/sha256";
 import { AgreementType } from "shared/validators";
-import { AIProvider } from "shared/ai";
+import { AIProvider, STTModel } from "shared/ai";
 import { NonJsonResponseError } from "shared/util";
 import { getOwnerDisplay as getOwnerDisplayName } from "@/services/owners";
 import {
@@ -129,6 +129,9 @@ export interface UserContextValue {
   // AI providers with a usable API key, from the org's own stored keys or the
   // host's environment variables.
   aiKeyProviders: AIProvider[];
+  // Resolved transcription model for voice dictation, or null when no provider
+  // with a key serves one. Null is what hides the dictation button.
+  sttModel: STTModel | null;
   seatsInUse: number;
   roles: Role[];
   teams?: Team[];
@@ -178,6 +181,7 @@ export const UserContext = createContext<UserContextValue>({
   organization: {},
   agreements: [],
   aiKeyProviders: [],
+  sttModel: null,
   subscription: null,
   licenseError: "",
   seatsInUse: 0,
@@ -603,6 +607,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
         commercialFeatures: [...commercialFeatures],
         agreements: currentOrg?.agreements || [],
         aiKeyProviders: currentOrg?.aiKeyProviders || [],
+        sttModel: currentOrg?.sttModel || null,
         organization: organization || {},
         seatsInUse: currentOrg?.seatsInUse || 0,
         teams,

--- a/packages/front-end/services/aiModelSelectOptions.ts
+++ b/packages/front-end/services/aiModelSelectOptions.ts
@@ -115,8 +115,7 @@ export const EMBEDDING_MODEL_OPTIONS =
 
 /** Transcription models for voice dictation, labeled with their provider. */
 export const STT_MODEL_OPTIONS = ensureValuesExactlyMatchUnion<STTModel>()([
-  // OpenAI. gpt-transcribe supersedes the gpt-4o pair; whisper-1 is the
-  // legacy floor, kept for proxies that only expose it.
+  // gpt-transcribe supersedes the gpt-4o pair; whisper-1 is the legacy floor.
   { value: "gpt-transcribe", label: "OpenAI: GPT Transcribe" },
   { value: "gpt-4o-transcribe", label: "OpenAI: GPT-4o Transcribe" },
   { value: "gpt-4o-mini-transcribe", label: "OpenAI: GPT-4o Mini Transcribe" },
@@ -196,9 +195,8 @@ export const USE_DEFAULT_EMBEDDING_MODEL_OPTION = {
 };
 
 /**
- * Names no model on purpose: which transcription model the default resolves to
- * depends on which provider keys exist, so naming one here would be wrong for
- * most orgs.
+ * Names no model: which one the default resolves to depends on which provider
+ * keys exist, so naming one here would be wrong for most orgs.
  */
 export const USE_DEFAULT_STT_MODEL_OPTION = {
   value: "",
@@ -294,9 +292,8 @@ export function getAvailableEmbeddingModelOptions(
 }
 
 /**
- * Transcription model options, filtered like the embedding ones. Providers that
- * serve no transcription model (Anthropic, Google) filter everything out and
- * leave only the sentinel — which is the honest answer: nothing to pick.
+ * Filtered like the embedding options. A provider list with no transcription
+ * model (Anthropic, Google) leaves only the sentinel — nothing to pick.
  */
 export function getAvailableSTTModelOptions(
   availableProviders: readonly AIProvider[] | undefined,

--- a/packages/front-end/services/aiModelSelectOptions.ts
+++ b/packages/front-end/services/aiModelSelectOptions.ts
@@ -1,4 +1,4 @@
-import type { AIModel, AIProvider, EmbeddingModel } from "shared/ai";
+import type { AIModel, AIProvider, EmbeddingModel, STTModel } from "shared/ai";
 import {
   AI_IMAGE_MODELS,
   AI_PROVIDER_MODEL_MAP,
@@ -113,6 +113,20 @@ export const EMBEDDING_MODEL_OPTIONS =
     { value: "gemini-embedding-001", label: "Google: gemini-embedding-001" },
   ]);
 
+/** Transcription models for voice dictation, labeled with their provider. */
+export const STT_MODEL_OPTIONS = ensureValuesExactlyMatchUnion<STTModel>()([
+  // OpenAI. gpt-transcribe supersedes the gpt-4o pair; whisper-1 is the
+  // legacy floor, kept for proxies that only expose it.
+  { value: "gpt-transcribe", label: "OpenAI: GPT Transcribe" },
+  { value: "gpt-4o-transcribe", label: "OpenAI: GPT-4o Transcribe" },
+  { value: "gpt-4o-mini-transcribe", label: "OpenAI: GPT-4o Mini Transcribe" },
+  { value: "whisper-1", label: "OpenAI: Whisper (legacy)" },
+  // xAI
+  { value: "grok-stt-1.0", label: "xAI: Grok STT 1.0" },
+  // Mistral. "(latest)" marks a rolling alias — the model behind it changes.
+  { value: "voxtral-mini-latest", label: "Mistral: Voxtral Mini (latest)" },
+]);
+
 function withSelectedOption<T extends FlatOption | GroupedOption>(
   options: T[],
   selected: string | undefined,
@@ -182,6 +196,16 @@ export const USE_DEFAULT_EMBEDDING_MODEL_OPTION = {
 };
 
 /**
+ * Names no model on purpose: which transcription model the default resolves to
+ * depends on which provider keys exist, so naming one here would be wrong for
+ * most orgs.
+ */
+export const USE_DEFAULT_STT_MODEL_OPTION = {
+  value: "",
+  label: "Use default dictation model",
+};
+
+/**
  * Clears the org's own default and hands the choice back to GrowthBook. Always
  * offered on Cloud — it is the only way back once a model is pinned, or once
  * the pinned one's provider key is removed.
@@ -197,6 +221,7 @@ export function getModelDisplayLabel(model: string): string {
     AI_MODEL_DISPLAY_LABELS[model as AIModel] ??
     getImageModelMeta(model)?.label ??
     EMBEDDING_MODEL_OPTIONS.find((o) => o.value === model)?.label ??
+    STT_MODEL_OPTIONS.find((o) => o.value === model)?.label ??
     model
   );
 }
@@ -265,5 +290,29 @@ export function getAvailableEmbeddingModelOptions(
     selectedModel,
     (value) =>
       EMBEDDING_MODEL_OPTIONS.find((o) => o.value === value)?.label ?? value,
+  );
+}
+
+/**
+ * Transcription model options, filtered like the embedding ones. Providers that
+ * serve no transcription model (Anthropic, Google) filter everything out and
+ * leave only the sentinel — which is the honest answer: nothing to pick.
+ */
+export function getAvailableSTTModelOptions(
+  availableProviders: readonly AIProvider[] | undefined,
+  selectedModel?: string,
+): (FlatOption | GroupedOption)[] {
+  const options =
+    availableProviders === undefined
+      ? STT_MODEL_OPTIONS
+      : STT_MODEL_OPTIONS.filter((o) => {
+          const provider = getProviderForAIModel("stt", o.value);
+          return provider === null || availableProviders.includes(provider);
+        });
+
+  return withSelectedOption(
+    [USE_DEFAULT_STT_MODEL_OPTION, ...options],
+    selectedModel,
+    (value) => STT_MODEL_OPTIONS.find((o) => o.value === value)?.label ?? value,
   );
 }

--- a/packages/front-end/test/aiModelSelectOptions.test.ts
+++ b/packages/front-end/test/aiModelSelectOptions.test.ts
@@ -211,8 +211,7 @@ describe("getAvailableSTTModelOptions", () => {
   });
 
   it("does not expose transcription models for an incompatible provider list", () => {
-    // Neither Anthropic nor Google serves a batch transcription model we
-    // support, so only the sentinel is left — which is what hides the button.
+    // Neither Anthropic nor Google serves one, so only the sentinel is left.
     expect(
       values(getAvailableSTTModelOptions(["anthropic", "google"])).filter(
         Boolean,
@@ -232,8 +231,7 @@ describe("getAvailableSTTModelOptions", () => {
   });
 
   it("labels every transcription model", () => {
-    // getModelDisplayLabel feeds the key-removal dialog, which prints the
-    // dictation fallback; an unlabeled id would surface as a raw model string.
+    // Feeds the key-removal dialog; an unlabeled id shows as a raw model id.
     for (const { value, label } of STT_MODEL_OPTIONS) {
       expect(getModelDisplayLabel(value)).toBe(label);
     }

--- a/packages/front-end/test/aiModelSelectOptions.test.ts
+++ b/packages/front-end/test/aiModelSelectOptions.test.ts
@@ -11,7 +11,9 @@ import {
   getAvailableEmbeddingModelOptions,
   getAvailableImageModelOptions,
   getAvailablePromptModelOptions,
+  getAvailableSTTModelOptions,
   getModelDisplayLabel,
+  STT_MODEL_OPTIONS,
   USE_DEFAULT_MODEL_OPTION,
 } from "@/services/aiModelSelectOptions";
 
@@ -190,5 +192,50 @@ describe("getAvailableEmbeddingModelOptions", () => {
     expect(values(getAvailableEmbeddingModelOptions(["anthropic"]))).toContain(
       "",
     );
+  });
+});
+
+describe("getAvailableSTTModelOptions", () => {
+  it("only offers transcription models from the given providers", () => {
+    const ids = values(getAvailableSTTModelOptions(["xai"]));
+
+    expect(ids).toContain("grok-stt-1.0");
+    expect(ids).not.toContain("gpt-transcribe");
+  });
+
+  it("keeps a saved transcription model selectable", () => {
+    const options = getAvailableSTTModelOptions(["xai"], "whisper-1");
+
+    expect(values(options)).toContain("whisper-1");
+    expect(groupLabels(options)).toContain("Selected, no API key");
+  });
+
+  it("does not expose transcription models for an incompatible provider list", () => {
+    // Neither Anthropic nor Google serves a batch transcription model we
+    // support, so only the sentinel is left — which is what hides the button.
+    expect(
+      values(getAvailableSTTModelOptions(["anthropic", "google"])).filter(
+        Boolean,
+      ),
+    ).toEqual([]);
+  });
+
+  it("shows every transcription model while provider access is unknown", () => {
+    expect(
+      values(getAvailableSTTModelOptions(undefined)).filter(Boolean),
+    ).toHaveLength(STT_MODEL_OPTIONS.length);
+  });
+
+  it("always keeps the 'use default' entry", () => {
+    // The only way back to the resolved default once a model has been chosen.
+    expect(values(getAvailableSTTModelOptions(["anthropic"]))).toContain("");
+  });
+
+  it("labels every transcription model", () => {
+    // getModelDisplayLabel feeds the key-removal dialog, which prints the
+    // dictation fallback; an unlabeled id would surface as a raw model string.
+    for (const { value, label } of STT_MODEL_OPTIONS) {
+      expect(getModelDisplayLabel(value)).toBe(label);
+    }
   });
 });

--- a/packages/shared/src/ai.ts
+++ b/packages/shared/src/ai.ts
@@ -590,6 +590,25 @@ export const SELF_HOSTED_DEFAULT_STT_MODELS: ReadonlyArray<
   ["mistral", "voxtral-mini-latest"],
 ];
 
+/**
+ * Which model "use default" resolves to, given the providers that have a key.
+ * Shared so the settings dropdown can name the default without re-deriving a
+ * chain that could disagree with what the transcribe route actually picks.
+ */
+export function resolveDefaultSTTModel(
+  providersWithKeys: readonly AIProvider[],
+  isCloud: boolean,
+): STTModel | null {
+  if (isCloud && providersWithKeys.includes("xai")) {
+    return CLOUD_MANAGED_STT_MODEL;
+  }
+  return (
+    SELF_HOSTED_DEFAULT_STT_MODELS.find(([provider]) =>
+      providersWithKeys.includes(provider),
+    )?.[1] ?? null
+  );
+}
+
 // Text, embedding, image and transcription models each have their own
 // registry, so callers holding an org setting must say which one it came from.
 export type AIModelKind = "text" | "embedding" | "image" | "stt";

--- a/packages/shared/src/ai.ts
+++ b/packages/shared/src/ai.ts
@@ -548,19 +548,13 @@ export function getProviderFromEmbeddingModel(
   throw new Error(`Embedding model ${model} is not supported.`);
 }
 
-// Speech-to-text models, for voice dictation in AI chat.
+// Speech-to-text models for voice dictation. Batch (file-POST) only: the
+// realtime ids each provider also ships need a socket, not a POST.
 //
-// Batch (file-POST) transcription only. Each provider also ships a realtime id
-// — gpt-live-transcribe, voxtral-mini-transcribe-realtime-2602, xAI's
-// wss://api.x.ai/v1/stt — and those need a socket, not a POST.
-//
-// Two providers are deliberately absent:
-//   Anthropic — no Claude model accepts audio input at all.
-//   Google — gemini-3.5-transcribe won't take inline audio. It needs a Files
-//     API upload first, then a POST to /v1beta/interactions (not
-//     generateContent) with its own request and response shape: two
-//     round-trips and an adapter as large as the other three providers
-//     combined, for a preview model. Add it if a Google-only org asks.
+// Anthropic is absent because no Claude model accepts audio input. Google is
+// absent because gemini-3.5-transcribe won't take inline audio — it needs a
+// Files API upload, then /v1beta/interactions with its own request and
+// response shape, which is more adapter than the other three combined.
 export const AI_PROVIDER_STT_MODEL_MAP = {
   openai: [
     "gpt-transcribe",
@@ -575,7 +569,6 @@ export const AI_PROVIDER_STT_MODEL_MAP = {
 export type STTModel =
   (typeof AI_PROVIDER_STT_MODEL_MAP)[keyof typeof AI_PROVIDER_STT_MODEL_MAP][number];
 
-// Which provider serves an STT model.
 export function getProviderFromSTTModel(model: STTModel): AIProvider {
   for (const [provider, models] of Object.entries(AI_PROVIDER_STT_MODEL_MAP)) {
     if (models.includes(model as never)) {
@@ -587,9 +580,8 @@ export function getProviderFromSTTModel(model: STTModel): AIProvider {
 
 export const CLOUD_MANAGED_STT_MODEL: STTModel = "grok-stt-1.0";
 
-// Self-hosted has no managed key, so the default follows whichever provider
-// the admin configured. Cloud walks this too when the managed model's provider
-// has no key, so dictation degrades to another provider instead of vanishing.
+// Walked in order by both deployments, so a missing key degrades to the next
+// provider rather than disabling dictation.
 export const SELF_HOSTED_DEFAULT_STT_MODELS: ReadonlyArray<
   [AIProvider, STTModel]
 > = [

--- a/packages/shared/src/ai.ts
+++ b/packages/shared/src/ai.ts
@@ -578,17 +578,18 @@ export function getProviderFromSTTModel(model: STTModel): AIProvider {
   throw new Error(`Transcription model ${model} is not supported.`);
 }
 
-export const CLOUD_MANAGED_STT_MODEL: STTModel = "grok-stt-1.0";
-
-// Walked in order by both deployments, so a missing key degrades to the next
-// provider rather than disabling dictation.
-export const SELF_HOSTED_DEFAULT_STT_MODELS: ReadonlyArray<
-  [AIProvider, STTModel]
-> = [
+// Walked in order, so a missing key degrades to the next provider rather than
+// disabling dictation. Same order on Cloud and self-hosted: whichever key is
+// present wins, and there is no managed model worth special-casing above it.
+export const DEFAULT_STT_MODELS: ReadonlyArray<[AIProvider, STTModel]> = [
   ["openai", "gpt-transcribe"],
   ["xai", "grok-stt-1.0"],
   ["mistral", "voxtral-mini-latest"],
 ];
+
+// What the key-removal dialog names as taking over. Derived from the list so
+// the two can't drift apart.
+export const DEFAULT_STT_MODEL: STTModel = DEFAULT_STT_MODELS[0][1];
 
 /**
  * Which model "use default" resolves to, given the providers that have a key.
@@ -597,13 +598,9 @@ export const SELF_HOSTED_DEFAULT_STT_MODELS: ReadonlyArray<
  */
 export function resolveDefaultSTTModel(
   providersWithKeys: readonly AIProvider[],
-  isCloud: boolean,
 ): STTModel | null {
-  if (isCloud && providersWithKeys.includes("xai")) {
-    return CLOUD_MANAGED_STT_MODEL;
-  }
   return (
-    SELF_HOSTED_DEFAULT_STT_MODELS.find(([provider]) =>
+    DEFAULT_STT_MODELS.find(([provider]) =>
       providersWithKeys.includes(provider),
     )?.[1] ?? null
   );
@@ -670,7 +667,7 @@ export const AI_MODEL_SETTINGS = [
     key: "sttModel",
     kind: "stt",
     label: "Dictation model",
-    fallback: CLOUD_MANAGED_STT_MODEL,
+    fallback: DEFAULT_STT_MODEL,
   },
 ] as const;
 

--- a/packages/shared/src/ai.ts
+++ b/packages/shared/src/ai.ts
@@ -548,9 +548,59 @@ export function getProviderFromEmbeddingModel(
   throw new Error(`Embedding model ${model} is not supported.`);
 }
 
-// Text, embedding and image models each have their own registry, so callers
-// holding an org setting must say which one it came from.
-export type AIModelKind = "text" | "embedding" | "image";
+// Speech-to-text models, for voice dictation in AI chat.
+//
+// Batch (file-POST) transcription only. Each provider also ships a realtime id
+// — gpt-live-transcribe, voxtral-mini-transcribe-realtime-2602, xAI's
+// wss://api.x.ai/v1/stt — and those need a socket, not a POST.
+//
+// Two providers are deliberately absent:
+//   Anthropic — no Claude model accepts audio input at all.
+//   Google — gemini-3.5-transcribe won't take inline audio. It needs a Files
+//     API upload first, then a POST to /v1beta/interactions (not
+//     generateContent) with its own request and response shape: two
+//     round-trips and an adapter as large as the other three providers
+//     combined, for a preview model. Add it if a Google-only org asks.
+export const AI_PROVIDER_STT_MODEL_MAP = {
+  openai: [
+    "gpt-transcribe",
+    "gpt-4o-transcribe",
+    "gpt-4o-mini-transcribe",
+    "whisper-1",
+  ],
+  xai: ["grok-stt-1.0"],
+  mistral: ["voxtral-mini-latest"],
+} as const;
+
+export type STTModel =
+  (typeof AI_PROVIDER_STT_MODEL_MAP)[keyof typeof AI_PROVIDER_STT_MODEL_MAP][number];
+
+// Which provider serves an STT model.
+export function getProviderFromSTTModel(model: STTModel): AIProvider {
+  for (const [provider, models] of Object.entries(AI_PROVIDER_STT_MODEL_MAP)) {
+    if (models.includes(model as never)) {
+      return provider as AIProvider;
+    }
+  }
+  throw new Error(`Transcription model ${model} is not supported.`);
+}
+
+export const CLOUD_MANAGED_STT_MODEL: STTModel = "grok-stt-1.0";
+
+// Self-hosted has no managed key, so the default follows whichever provider
+// the admin configured. Cloud walks this too when the managed model's provider
+// has no key, so dictation degrades to another provider instead of vanishing.
+export const SELF_HOSTED_DEFAULT_STT_MODELS: ReadonlyArray<
+  [AIProvider, STTModel]
+> = [
+  ["openai", "gpt-transcribe"],
+  ["xai", "grok-stt-1.0"],
+  ["mistral", "voxtral-mini-latest"],
+];
+
+// Text, embedding, image and transcription models each have their own
+// registry, so callers holding an org setting must say which one it came from.
+export type AIModelKind = "text" | "embedding" | "image" | "stt";
 
 // Provider that serves `model`, or null when the id isn't in that registry.
 // Null rather than a throw: a stale org setting should read as "not selectable",
@@ -563,6 +613,7 @@ export function getProviderForAIModel(
     if (kind === "text") return getProviderFromModel(model as AIModel);
     if (kind === "embedding")
       return getProviderFromEmbeddingModel(model as EmbeddingModel);
+    if (kind === "stt") return getProviderFromSTTModel(model as STTModel);
     return getImageModelMeta(model)?.provider ?? null;
   } catch {
     return null;
@@ -603,6 +654,12 @@ export const AI_MODEL_SETTINGS = [
     kind: "embedding",
     label: "Embedding model",
     fallback: DEFAULT_EMBEDDING_MODEL,
+  },
+  {
+    key: "sttModel",
+    kind: "stt",
+    label: "Dictation model",
+    fallback: CLOUD_MANAGED_STT_MODEL,
   },
 ] as const;
 

--- a/packages/shared/test/ai.test.ts
+++ b/packages/shared/test/ai.test.ts
@@ -265,29 +265,32 @@ describe("getAIModelSettingsUsingProvider", () => {
 });
 
 describe("resolveDefaultSTTModel", () => {
-  it("prefers the managed Grok model on Cloud", () => {
-    expect(resolveDefaultSTTModel(["openai", "xai"], true)).toBe(
-      "grok-stt-1.0",
-    );
-  });
-
-  it("falls through to the next provider when Cloud has no xAI key", () => {
-    // The managed key isn't guaranteed, so dictation degrades rather than
-    // disappearing — this is the case a live Cloud org hits.
-    expect(resolveDefaultSTTModel(["openai"], true)).toBe("gpt-transcribe");
-    expect(resolveDefaultSTTModel(["mistral"], true)).toBe(
-      "voxtral-mini-latest",
-    );
-  });
-
-  it("ignores the managed model when self-hosted", () => {
-    expect(resolveDefaultSTTModel(["xai", "openai"], false)).toBe(
+  it("prefers gpt-transcribe", () => {
+    expect(resolveDefaultSTTModel(["openai", "xai", "mistral"])).toBe(
       "gpt-transcribe",
     );
   });
 
+  it("falls through in order when OpenAI has no key", () => {
+    // Degrades to the next provider rather than disabling dictation.
+    expect(resolveDefaultSTTModel(["xai", "mistral"])).toBe("grok-stt-1.0");
+    expect(resolveDefaultSTTModel(["mistral"])).toBe("voxtral-mini-latest");
+  });
+
+  it("serves a Cloud org with no keys of its own", () => {
+    // Enterprise Cloud without BYOK: the provider list is GrowthBook's managed
+    // keys, and dictation resolves off those rather than requiring the org to
+    // bring one. Anthropic alone is the one combination that yields nothing,
+    // since no Claude model accepts audio.
+    expect(resolveDefaultSTTModel(["anthropic", "openai"])).toBe(
+      "gpt-transcribe",
+    );
+    expect(resolveDefaultSTTModel(["anthropic", "xai"])).toBe("grok-stt-1.0");
+    expect(resolveDefaultSTTModel(["anthropic"])).toBeNull();
+  });
+
   it("returns null when no provider serves transcription", () => {
-    expect(resolveDefaultSTTModel(["anthropic", "google"], true)).toBeNull();
-    expect(resolveDefaultSTTModel([], false)).toBeNull();
+    expect(resolveDefaultSTTModel(["anthropic", "google"])).toBeNull();
+    expect(resolveDefaultSTTModel([])).toBeNull();
   });
 });

--- a/packages/shared/test/ai.test.ts
+++ b/packages/shared/test/ai.test.ts
@@ -1,4 +1,5 @@
 import {
+  AI_PROVIDER_STT_MODEL_MAP,
   formatAIRateLimitRetryMessage,
   getAIModelSettingsUsingProvider,
   getProviderForAIModel,
@@ -41,11 +42,31 @@ describe("getProviderForAIModel", () => {
     ).toBe("google");
   });
 
+  it("resolves transcription models from their own registry", () => {
+    expect(getProviderForAIModel("stt", "grok-stt-1.0")).toBe("xai");
+    expect(getProviderForAIModel("stt", "gpt-transcribe")).toBe("openai");
+    expect(getProviderForAIModel("stt", "voxtral-mini-latest")).toBe("mistral");
+    // Transcription ids are not text models and vice versa.
+    expect(getProviderForAIModel("text", "grok-stt-1.0")).toBeNull();
+    expect(getProviderForAIModel("stt", "grok-4.6")).toBeNull();
+  });
+
+  it("has no transcription model for Anthropic or Google", () => {
+    // Claude takes no audio input, and gemini-3.5-transcribe needs the
+    // Files API + /v1beta/interactions rather than an inline POST.
+    for (const model of Object.values(AI_PROVIDER_STT_MODEL_MAP).flat()) {
+      expect(["anthropic", "google"]).not.toContain(
+        getProviderForAIModel("stt", model),
+      );
+    }
+  });
+
   it("returns null for an unknown id rather than throwing", () => {
     // Read off saved org settings, so a stale value must not throw.
     expect(getProviderForAIModel("text", "not-a-model")).toBeNull();
     expect(getProviderForAIModel("embedding", "not-a-model")).toBeNull();
     expect(getProviderForAIModel("image", "not-a-model")).toBeNull();
+    expect(getProviderForAIModel("stt", "not-a-model")).toBeNull();
     expect(getProviderForAIModel("text", "")).toBeNull();
   });
 });
@@ -211,6 +232,19 @@ describe("getAIModelSettingsUsingProvider", () => {
 
   it("returns nothing for a provider no setting uses", () => {
     expect(getAIModelSettingsUsingProvider(settings, "mistral")).toEqual([]);
+  });
+
+  it("finds the dictation setting", () => {
+    // Removing the key behind a stored dictation model has to clear it, or
+    // transcription keeps pointing at a provider with no credentials.
+    expect(
+      getAIModelSettingsUsingProvider({ sttModel: "grok-stt-1.0" }, "xai").map(
+        (s) => s.key,
+      ),
+    ).toEqual(["sttModel"]);
+    expect(
+      getAIModelSettingsUsingProvider({ sttModel: "grok-stt-1.0" }, "openai"),
+    ).toEqual([]);
   });
 
   it("catches the legacy openAIDefaultModel field", () => {

--- a/packages/shared/test/ai.test.ts
+++ b/packages/shared/test/ai.test.ts
@@ -1,5 +1,6 @@
 import {
   AI_PROVIDER_STT_MODEL_MAP,
+  resolveDefaultSTTModel,
   formatAIRateLimitRetryMessage,
   getAIModelSettingsUsingProvider,
   getProviderForAIModel,
@@ -260,5 +261,33 @@ describe("getAIModelSettingsUsingProvider", () => {
         "openai",
       ),
     ).toEqual([]);
+  });
+});
+
+describe("resolveDefaultSTTModel", () => {
+  it("prefers the managed Grok model on Cloud", () => {
+    expect(resolveDefaultSTTModel(["openai", "xai"], true)).toBe(
+      "grok-stt-1.0",
+    );
+  });
+
+  it("falls through to the next provider when Cloud has no xAI key", () => {
+    // The managed key isn't guaranteed, so dictation degrades rather than
+    // disappearing — this is the case a live Cloud org hits.
+    expect(resolveDefaultSTTModel(["openai"], true)).toBe("gpt-transcribe");
+    expect(resolveDefaultSTTModel(["mistral"], true)).toBe(
+      "voxtral-mini-latest",
+    );
+  });
+
+  it("ignores the managed model when self-hosted", () => {
+    expect(resolveDefaultSTTModel(["xai", "openai"], false)).toBe(
+      "gpt-transcribe",
+    );
+  });
+
+  it("returns null when no provider serves transcription", () => {
+    expect(resolveDefaultSTTModel(["anthropic", "google"], true)).toBeNull();
+    expect(resolveDefaultSTTModel([], false)).toBeNull();
   });
 });

--- a/packages/shared/test/ai.test.ts
+++ b/packages/shared/test/ai.test.ts
@@ -52,8 +52,6 @@ describe("getProviderForAIModel", () => {
   });
 
   it("has no transcription model for Anthropic or Google", () => {
-    // Claude takes no audio input, and gemini-3.5-transcribe needs the
-    // Files API + /v1beta/interactions rather than an inline POST.
     for (const model of Object.values(AI_PROVIDER_STT_MODEL_MAP).flat()) {
       expect(["anthropic", "google"]).not.toContain(
         getProviderForAIModel("stt", model),
@@ -235,8 +233,7 @@ describe("getAIModelSettingsUsingProvider", () => {
   });
 
   it("finds the dictation setting", () => {
-    // Removing the key behind a stored dictation model has to clear it, or
-    // transcription keeps pointing at a provider with no credentials.
+    // Removing the key behind a stored dictation model has to clear it.
     expect(
       getAIModelSettingsUsingProvider({ sttModel: "grok-stt-1.0" }, "xai").map(
         (s) => s.key,

--- a/packages/shared/types/organization.d.ts
+++ b/packages/shared/types/organization.d.ts
@@ -18,7 +18,7 @@ import {
   OrgLimits,
   SubscriptionInfo,
 } from "shared/enterprise";
-import { AIModel, AIProvider, EmbeddingModel } from "shared/ai";
+import { AIModel, AIProvider, EmbeddingModel, STTModel } from "shared/ai";
 import {
   AgreementType,
   environment,
@@ -283,6 +283,10 @@ export interface OrganizationSettings {
   aiEnabled?: boolean;
   defaultAIModel?: AIModel;
   embeddingModel?: EmbeddingModel;
+  // Voice dictation in AI chat. Unset resolves per getAISettingsForOrg, which
+  // returns null when no provider with a key serves transcription — that null
+  // is what hides the mic button.
+  sttModel?: STTModel;
   /** @deprecated */
   openAIDefaultModel?: AIModel;
   // Per-surface overrides for the Visual Editor. Image model is a free
@@ -554,6 +558,8 @@ export type GetOrganizationResponse = {
   // Providers with a usable key, stored or inherited from the environment.
   // Non-secret, and rides along here so AI gating needs no separate request.
   aiKeyProviders: AIProvider[];
+  // Resolved transcription model for voice dictation, null when unavailable.
+  sttModel: STTModel | null;
 };
 
 export type DailyUsage = {

--- a/packages/shared/types/organization.d.ts
+++ b/packages/shared/types/organization.d.ts
@@ -283,9 +283,7 @@ export interface OrganizationSettings {
   aiEnabled?: boolean;
   defaultAIModel?: AIModel;
   embeddingModel?: EmbeddingModel;
-  // Voice dictation in AI chat. Unset resolves per getAISettingsForOrg, which
-  // returns null when no provider with a key serves transcription — that null
-  // is what hides the mic button.
+  // Voice dictation. Unset resolves in getAISettingsForOrg.
   sttModel?: STTModel;
   /** @deprecated */
   openAIDefaultModel?: AIModel;
@@ -558,7 +556,7 @@ export type GetOrganizationResponse = {
   // Providers with a usable key, stored or inherited from the environment.
   // Non-secret, and rides along here so AI gating needs no separate request.
   aiKeyProviders: AIProvider[];
-  // Resolved transcription model for voice dictation, null when unavailable.
+  // Resolved dictation model, null when unavailable. Hides the mic button.
   sttModel: STTModel | null;
 };
 


### PR DESCRIPTION
### Features and Changes

- Add Audio dictation support to AI Assistant panel 
- Only support OpenAI, Mistral (built on top of OpenAI transcribe model) and xAI
- Gemini (they have a model but it requires uploading the file, then upload again to our system. It's a mess atm) and Anthropic aren't supported.
- The Dictation button ONLY shows when they have any of the 3 supported AI providers.
- Follow the same restriction as other AI related stuffs: Enterprise only.

- Closes **(add link to issue here)**

### Dependencies
N/A

### Testing

- [x] Open the AI Assistant panel and click on Dictation to record the entire message
- [x] Type part of the message into the chat then click on Dictation button --> say something --> check if it appends

### Screenshots

<img width="667" height="240" alt="Screenshot 2026-09-10 at 14 19 33" src="https://github.com/user-attachments/assets/a97dd50a-2b82-4604-a004-27bbddf520a5" />
<img width="676" height="117" alt="Screenshot 2026-09-10 at 14 19 36" src="https://github.com/user-attachments/assets/8560b863-c63b-4c44-9392-e5012775bb94" />
