### PR TITLE
feat(experiments): handle errored metrics in experiment decision framework

### DIFF
--- a/packages/back-end/src/api/experiments/enhancedExperimentResponse.ts
+++ b/packages/back-end/src/api/experiments/enhancedExperimentResponse.ts
@@ -24,13 +24,15 @@ export async function toEnhancedExperimentApiResponse(
     context,
     experiment,
   );
+  const metricGroups = await context.models.metricGroups.getAll();
 
-  const { status, detailedStatus } = getStatusIndicatorData(
-    experiment,
-    false,
+  const { status, detailedStatus } = getStatusIndicatorData({
+    experimentData: experiment,
+    skipArchived: false,
     healthSettings,
     decisionCriteria,
-  );
+    metricGroups,
+  });
   const enhancedStatus = { status, detailedStatus };
 
   const apiExperiment = await resolveOwnerEmail(

--- a/packages/back-end/src/jobs/updateExperimentStatus.ts
+++ b/packages/back-end/src/jobs/updateExperimentStatus.ts
@@ -158,10 +158,13 @@ const updateSingleExperimentStatus = async (
           return;
         }
 
+        const metricGroups = await context.models.metricGroups.getAll();
+
         // A stop refreshes the SDK payload as a side effect.
         const outcome = await applyScheduledExperimentStop({
           context,
           experiment,
+          metricGroups,
         });
 
         // The scheduled end passing can flip the EDF status to decisive
@@ -169,7 +172,7 @@ const updateSingleExperimentStatus = async (
         // experiment (post-stop it's no longer "running", so scheduledEndPassed
         // would be false) and fire the decision.* event for every outcome,
         // ordered before the scheduled-status-update event.
-        await notifyScheduledEndDecision({ context, experiment });
+        await notifyScheduledEndDecision({ context, experiment, metricGroups });
 
         // Re-load: stopExperiment may have already mutated the experiment, and
         // the notification below needs fresh state either way.

--- a/packages/back-end/src/services/experimentNotifications.ts
+++ b/packages/back-end/src/services/experimentNotifications.ts
@@ -23,6 +23,7 @@ import {
   ExperimentResultStatusData,
 } from "shared/types/experiment";
 import { ExperimentSnapshotInterface } from "shared/types/experiment-snapshot";
+import { MetricGroupInterface } from "shared/types/metric-groups";
 import { ResourceEvents } from "shared/types/events/base-types";
 import { orgHasPremiumFeature } from "back-end/src/enterprise";
 import { Context } from "back-end/src/models/BaseModel";
@@ -706,9 +707,11 @@ async function getDecisionCriteria(
 export const notifyScheduledEndDecision = async ({
   context,
   experiment,
+  metricGroups,
 }: {
   context: Context;
   experiment: ExperimentInterface;
+  metricGroups: MetricGroupInterface[];
 }) => {
   const healthSettings = getHealthSettings(
     context.org.settings,
@@ -724,6 +727,7 @@ export const notifyScheduledEndDecision = async ({
     experimentData: experiment,
     healthSettings,
     decisionCriteria,
+    metricGroups,
   });
   if (!currentStatus) return false;
 
@@ -731,6 +735,7 @@ export const notifyScheduledEndDecision = async ({
     experimentData: { ...experiment, statusUpdateSchedule: null },
     healthSettings,
     decisionCriteria,
+    metricGroups,
   });
 
   return notifyDecision({
@@ -771,11 +776,13 @@ export const notifyExperimentChange = async ({
     experiment.decisionFrameworkSettings?.decisionCriteriaId ??
       context.org.settings?.defaultDecisionCriteriaId,
   );
+  const metricGroups = await context.models.metricGroups.getAll();
 
   const currentStatus = getExperimentResultStatus({
     experimentData: experiment,
     healthSettings,
     decisionCriteria,
+    metricGroups,
   });
 
   const triggeredNoData = await notifyNoData({
@@ -827,6 +834,7 @@ export const notifyExperimentChange = async ({
       },
       healthSettings,
       decisionCriteria,
+      metricGroups,
     });
     const triggeredDecision = await notifyDecision({
       context,

--- a/packages/back-end/src/services/experimentScheduling.ts
+++ b/packages/back-end/src/services/experimentScheduling.ts
@@ -1,4 +1,6 @@
 import { ExperimentInterface } from "shared/types/experiment";
+import { MetricGroupInterface } from "shared/types/metric-groups";
+import { expandMetricGroups } from "shared/experiments";
 import { DEFAULT_DECISION_FRAMEWORK_ENABLED } from "shared/constants";
 import {
   ExperimentType,
@@ -86,6 +88,7 @@ async function computeScheduledVerdict(
   context: Context,
   experiment: ExperimentInterface,
   tiebreakerMetricId: string | undefined,
+  metricGroups: MetricGroupInterface[],
 ): Promise<ScheduledVerdict | null> {
   if (!canAutoShip(context)) return null;
 
@@ -101,12 +104,17 @@ async function computeScheduledVerdict(
   };
 
   const resultsStatus = experiment.analysisSummary?.resultsStatus;
-  if (!experiment.goalMetrics.length || !resultsStatus) return inconclusive;
+  const expandedGoalMetrics = expandMetricGroups(
+    experiment.goalMetrics,
+    metricGroups,
+  );
+  if (!expandedGoalMetrics.length || !resultsStatus) return inconclusive;
 
   const overallStatus = getExperimentResultStatus({
     experimentData: experiment,
     healthSettings: getHealthSettings(context.org.settings, true),
     decisionCriteria,
+    metricGroups,
   });
   if (
     overallStatus?.status === "unhealthy" &&
@@ -122,8 +130,11 @@ async function computeScheduledVerdict(
   const resultStatus = getDecisionFrameworkStatus({
     resultsStatus,
     decisionCriteria,
-    goalMetrics: experiment.goalMetrics,
-    guardrailMetrics: experiment.guardrailMetrics,
+    goalMetrics: expandedGoalMetrics,
+    guardrailMetrics: expandMetricGroups(
+      experiment.guardrailMetrics,
+      metricGroups,
+    ),
     scheduledEndPassed: true,
   });
   if (!resultStatus) return inconclusive;
@@ -189,9 +200,11 @@ const resolveForceShipTarget = (
 export async function applyScheduledExperimentStop({
   context,
   experiment,
+  metricGroups,
 }: {
   context: Context;
   experiment: ExperimentInterface;
+  metricGroups: MetricGroupInterface[];
 }): Promise<ScheduledStopOutcome> {
   const plan = experiment.statusUpdateSchedule?.scheduledStopPlan;
   const mode = plan?.mode ?? "notify";
@@ -206,6 +219,7 @@ export async function applyScheduledExperimentStop({
       context,
       experiment,
       tiebreakerMetricId,
+      metricGroups,
     );
     if (verdict?.results === "won" && verdict.winnerVariationId) {
       await stopExperiment({
@@ -274,6 +288,7 @@ export async function applyScheduledExperimentStop({
       context,
       experiment,
       tiebreakerMetricId,
+      metricGroups,
     );
     await stopExperiment({
       context,
@@ -299,6 +314,7 @@ export async function applyScheduledExperimentStop({
       context,
       experiment,
       tiebreakerMetricId,
+      metricGroups,
     );
     await stopExperiment({
       context,
@@ -319,6 +335,7 @@ export async function applyScheduledExperimentStop({
     context,
     experiment,
     tiebreakerMetricId,
+    metricGroups,
   );
   logger.info(
     `Scheduled end reached; keeping experiment ${experiment.id} running (notify).`,

--- a/packages/front-end/components/Experiment/TabbedPage/ScheduledEndPassedBanner.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ScheduledEndPassedBanner.tsx
@@ -34,7 +34,7 @@ function getReasonText(statusData: NonDecisiveStatusData): string {
         ? `${statusData.tooltip}.`
         : "There is no data yet.";
     case "data-incomplete":
-      return "Some metrics could not be computed, so no decision recommendation is available.";
+      return "One or more goal or guardrail metrics could not be computed, so no decision recommendation is available.";
     case "scheduled-end-review":
       return statusData.tooltip ?? "No decision recommendation is available.";
     case "days-left":

--- a/packages/front-end/components/Experiment/TabbedPage/ScheduledEndPassedBanner.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ScheduledEndPassedBanner.tsx
@@ -33,6 +33,8 @@ function getReasonText(statusData: NonDecisiveStatusData): string {
       return statusData.tooltip
         ? `${statusData.tooltip}.`
         : "There is no data yet.";
+    case "data-incomplete":
+      return "Some metrics could not be computed, so no decision recommendation is available.";
     case "scheduled-end-review":
       return statusData.tooltip ?? "No decision recommendation is available.";
     case "days-left":

--- a/packages/front-end/components/Features/SafeRollout/SafeRolloutStatusModal.tsx
+++ b/packages/front-end/components/Features/SafeRollout/SafeRolloutStatusModal.tsx
@@ -65,6 +65,7 @@ function getDefaultStatusAndText(
     case "before-min-duration":
     case "days-left":
     case "no-data":
+    case "data-incomplete":
       return {
         defaultStatus: "",
         text: "The Safe Rollout is still collecting data. Are you sure you want to stop early?",

--- a/packages/front-end/components/Features/SafeRollout/SafeRolloutStatusModal.tsx
+++ b/packages/front-end/components/Features/SafeRollout/SafeRolloutStatusModal.tsx
@@ -62,10 +62,14 @@ function getDefaultStatusAndText(
         defaultStatus: "rolled-back",
         text: "The Safe Rollout has failing guardrails. We recommend reverting to Control.",
       };
+    case "data-incomplete":
+      return {
+        defaultStatus: "",
+        text: "Some guardrail metrics could not be computed, so no ship recommendation is available.",
+      };
     case "before-min-duration":
     case "days-left":
     case "no-data":
-    case "data-incomplete":
       return {
         defaultStatus: "",
         text: "The Safe Rollout is still collecting data. Are you sure you want to stop early?",

--- a/packages/front-end/components/SafeRollout/DecisionCTA.tsx
+++ b/packages/front-end/components/SafeRollout/DecisionCTA.tsx
@@ -52,7 +52,7 @@ const DecisionCTA = ({
     return null;
   }
 
-  let buttonCopy = "Stop Early";
+  let buttonCopy = "End rollout";
   let variant: Variant = "soft";
   let color: Color = "violet";
 
@@ -66,8 +66,6 @@ const DecisionCTA = ({
   } else if (decisionStatus?.status === "ship-now") {
     buttonCopy = "Ship Now";
     variant = "solid";
-  } else if (decisionStatus?.status === "data-incomplete") {
-    buttonCopy = "Review rollout";
   }
 
   return (

--- a/packages/front-end/components/SafeRollout/DecisionCTA.tsx
+++ b/packages/front-end/components/SafeRollout/DecisionCTA.tsx
@@ -66,6 +66,8 @@ const DecisionCTA = ({
   } else if (decisionStatus?.status === "ship-now") {
     buttonCopy = "Ship Now";
     variant = "solid";
+  } else if (decisionStatus?.status === "data-incomplete") {
+    buttonCopy = "Review rollout";
   }
 
   return (

--- a/packages/front-end/components/SafeRollout/DecisionHelpText.tsx
+++ b/packages/front-end/components/SafeRollout/DecisionHelpText.tsx
@@ -116,6 +116,13 @@ const DecisionHelpText = ({ rule }: { rule: SafeRolloutRule }) => {
         Guardrails are failing and the Safe Rollout should be reverted.
       </HelperText>
     );
+  } else if (decisionStatus.status === "data-incomplete") {
+    return (
+      <HelperText status="warning" mb="3">
+        Some guardrail metrics could not be computed, so no ship recommendation
+        is available.
+      </HelperText>
+    );
   } else if (decisionStatus.status === "ship-now") {
     return (
       <HelperText status="success" mb="3">

--- a/packages/front-end/components/SafeRollout/SafeRolloutStatusBadge.tsx
+++ b/packages/front-end/components/SafeRollout/SafeRolloutStatusBadge.tsx
@@ -58,6 +58,9 @@ const SafeRolloutStatusBadge = ({ rule }: { rule: SafeRolloutRule }) => {
   } else if (decisionStatus?.status === "rollback-now") {
     color = "red";
     label = "Guardrails Failing";
+  } else if (decisionStatus?.status === "data-incomplete") {
+    color = "amber";
+    label = "Data incomplete";
   } else if (decisionStatus?.status === "ship-now") {
     color = "green";
     label = "Ready to ship";

--- a/packages/front-end/hooks/useExperimentStatusIndicator.ts
+++ b/packages/front-end/hooks/useExperimentStatusIndicator.ts
@@ -11,6 +11,7 @@ import {
   ExperimentDataForStatusStringDates,
   ExperimentHealthSettings,
 } from "shared/types/experiment";
+import { MetricGroupInterface } from "shared/types/metric-groups";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import { useUser } from "@/services/UserContext";
 import { useDefinitions } from "@/services/DefinitionsContext";
@@ -55,7 +56,7 @@ function getExperimentDecisionCriteria({
 
 export function useRunningExperimentStatus() {
   const { hasCommercialFeature } = useUser();
-  const { decisionCriteria } = useDefinitions();
+  const { decisionCriteria, metricGroups } = useDefinitions();
   const settings = useOrgSettings();
   const healthSettings = getHealthSettings(
     settings,
@@ -75,6 +76,7 @@ export function useRunningExperimentStatus() {
       getRunningExperimentResultStatus({
         experimentData,
         healthSettings,
+        metricGroups,
         decisionCriteria: getExperimentDecisionCriteria({
           orgCustomDecisionCriterias: decisionCriteria,
           experimentDecisionCriteriaId:
@@ -87,7 +89,8 @@ export function useRunningExperimentStatus() {
 
 export function useExperimentStatusIndicator() {
   const { hasCommercialFeature } = useUser();
-  const { decisionCriteria } = useDefinitions();
+  const { decisionCriteria, metricGroups, getExperimentMetricById } =
+    useDefinitions();
   const settings = useOrgSettings();
   const healthSettings = getHealthSettings(
     settings,
@@ -98,27 +101,32 @@ export function useExperimentStatusIndicator() {
     experimentData: ExperimentDataForStatusStringDates,
     skipArchived: boolean = false,
   ) =>
-    getStatusIndicatorData(
+    getStatusIndicatorData({
       experimentData,
       skipArchived,
       healthSettings,
-      getExperimentDecisionCriteria({
+      decisionCriteria: getExperimentDecisionCriteria({
         orgCustomDecisionCriterias: decisionCriteria,
         experimentDecisionCriteriaId:
           experimentData.decisionFrameworkSettings?.decisionCriteriaId,
         defaultDecisionCriteriaId: settings?.defaultDecisionCriteriaId,
       }),
-    );
+      metricGroups,
+      resolveMetricName: (metricId) =>
+        getExperimentMetricById(metricId)?.name ?? metricId,
+    });
 }
 
 function getRunningExperimentResultStatus({
   experimentData,
   healthSettings,
   decisionCriteria,
+  metricGroups,
 }: {
   experimentData: ExperimentDataForStatusStringDates;
   healthSettings: ExperimentHealthSettings;
   decisionCriteria: DecisionCriteriaData;
+  metricGroups: MetricGroupInterface[];
 }) {
   if (experimentData.status !== "running") {
     return undefined;
@@ -127,5 +135,6 @@ function getRunningExperimentResultStatus({
     experimentData,
     healthSettings,
     decisionCriteria,
+    metricGroups,
   });
 }

--- a/packages/shared/src/enterprise/decision-criteria/decisionCriteria.ts
+++ b/packages/shared/src/enterprise/decision-criteria/decisionCriteria.ts
@@ -868,6 +868,10 @@ export function getSafeRolloutResultStatus({
     };
   }
 
+  if (decisionStatus?.status === "data-incomplete") {
+    return decisionStatus;
+  }
+
   // If no decision status, return days left status
   if (daysLeft > 0) {
     return {

--- a/packages/shared/src/enterprise/decision-criteria/decisionCriteria.ts
+++ b/packages/shared/src/enterprise/decision-criteria/decisionCriteria.ts
@@ -1,7 +1,12 @@
 import { addDays, differenceInHours, differenceInMinutes } from "date-fns";
-import { getLatestPhaseVariations } from "shared/experiments";
+import {
+  expandMetricGroups,
+  getLatestPhaseVariations,
+} from "shared/experiments";
+import { MetricGroupInterface } from "shared/types/metric-groups";
 import {
   DecisionCriteriaAction,
+  DecisionCriteriaCondition,
   DecisionCriteriaData,
   DecisionCriteriaRule,
   DecisionFrameworkExperimentRecommendationStatus,
@@ -36,8 +41,44 @@ import {
   PRESET_DECISION_CRITERIAS,
 } from "./constants";
 
-// Evaluate a single rule on a variation result
-// Returns the action if the rule is met, otherwise undefined
+export type MatchResult = "matched" | "not-matched" | "indeterminate";
+
+// Failed metrics make a condition indeterminate unless known metrics decide it.
+function evaluateConditionMatch({
+  values,
+  desiredStatus,
+  match,
+}: {
+  values: (string | undefined)[];
+  desiredStatus: string;
+  match: DecisionCriteriaCondition["match"];
+}): MatchResult {
+  const known = values.filter((v) => v !== "failed");
+  const anyFailed = values.some((v) => v === "failed");
+
+  switch (match) {
+    case "all":
+      if (known.some((v) => v !== desiredStatus)) {
+        return "not-matched";
+      }
+      return anyFailed ? "indeterminate" : "matched";
+
+    case "any":
+      if (known.some((v) => v === desiredStatus)) {
+        return "matched";
+      }
+      return anyFailed ? "indeterminate" : "not-matched";
+
+    case "none":
+      if (known.some((v) => v === desiredStatus)) {
+        return "not-matched";
+      }
+      return anyFailed ? "indeterminate" : "matched";
+  }
+}
+
+// A rule matches when every condition holds. A definite non-match wins over
+// an unresolved condition elsewhere in the rule.
 export function evaluateDecisionRuleOnVariation({
   rule,
   variationStatus,
@@ -50,62 +91,136 @@ export function evaluateDecisionRuleOnVariation({
   goalMetrics: string[];
   guardrailMetrics: string[];
   requireSuperStatSig: boolean;
-}): DecisionCriteriaAction | undefined {
-  const { conditions, action } = rule;
+}): MatchResult {
+  const { conditions } = rule;
 
-  const allConditionsMet = conditions.every((condition) => {
+  let hasIndeterminateCondition = false;
+  for (const condition of conditions) {
     const desiredStatus =
       condition.direction === "statsigWinner"
         ? "won"
         : condition.direction === "statsigLoser"
           ? "lost"
           : "neutral";
-    if (condition.metrics === "goals") {
-      const metrics = goalMetrics;
-      const metricResults = variationStatus.goalMetrics;
 
-      const fieldToCheck = requireSuperStatSig
-        ? "superStatSigStatus"
-        : "status";
-
-      if (condition.match === "all") {
-        return metrics.every(
-          (m) => metricResults?.[m]?.[fieldToCheck] === desiredStatus,
+    let values: (string | undefined)[];
+    switch (condition.metrics) {
+      case "goals": {
+        const fieldToCheck = requireSuperStatSig
+          ? "superStatSigStatus"
+          : "status";
+        values = goalMetrics.map(
+          (m) => variationStatus.goalMetrics?.[m]?.[fieldToCheck],
         );
-      } else if (condition.match === "any") {
-        return metrics.some(
-          (m) => metricResults?.[m]?.[fieldToCheck] === desiredStatus,
-        );
-      } else if (condition.match === "none") {
-        return metrics.every(
-          (m) => metricResults?.[m]?.[fieldToCheck] !== desiredStatus,
-        );
+        break;
       }
-    } else if (condition.metrics === "guardrails") {
-      const metrics = guardrailMetrics;
-      const metricResults = variationStatus.guardrailMetrics;
 
-      if (condition.match === "all") {
-        return metrics.every(
-          (m) => metricResults?.[m]?.status === desiredStatus,
+      case "guardrails":
+        values = guardrailMetrics.map(
+          (m) => variationStatus.guardrailMetrics?.[m]?.status,
         );
-      } else if (condition.match === "any") {
-        return metrics.some(
-          (m) => metricResults?.[m]?.status === desiredStatus,
-        );
-      } else if (condition.match === "none") {
-        return metrics.every(
-          (m) => metricResults?.[m]?.status !== desiredStatus,
-        );
-      }
+        break;
     }
-  });
 
-  if (allConditionsMet) {
-    return action;
+    const result = evaluateConditionMatch({
+      values,
+      desiredStatus,
+      match: condition.match,
+    });
+
+    switch (result) {
+      case "matched":
+        continue;
+
+      case "not-matched":
+        return "not-matched";
+
+      case "indeterminate":
+        hasIndeterminateCondition = true;
+        continue;
+    }
   }
 
-  return undefined;
+  return hasIndeterminateCondition ? "indeterminate" : "matched";
+}
+
+type UndecidedVariation = DecisionFrameworkVariation & { decidingRule: null };
+
+export type VariationDecision =
+  | {
+      status: "decided";
+      variation: DecisionFrameworkVariation;
+      decisionCriteriaAction: DecisionCriteriaAction;
+    }
+  | { status: "pending"; variation: UndecidedVariation }
+  | { status: "indeterminate"; variation: UndecidedVariation };
+
+// Rollback takes priority; an unresolved higher rule blocks ship and review.
+function decideVariation({
+  variation,
+  rules,
+  goalMetrics,
+  guardrailMetrics,
+  requireSuperStatSig,
+  fallbackAction,
+}: {
+  variation: ExperimentAnalysisSummaryVariationStatus;
+  rules: DecisionCriteriaRule[];
+  goalMetrics: string[];
+  guardrailMetrics: string[];
+  requireSuperStatSig: boolean;
+  fallbackAction: DecisionCriteriaAction | null;
+}): VariationDecision {
+  let hasIndeterminateRule = false;
+  const undecided: UndecidedVariation = {
+    variationId: variation.variationId,
+    decidingRule: null,
+  };
+
+  for (const rule of rules) {
+    const outcome = evaluateDecisionRuleOnVariation({
+      rule,
+      variationStatus: variation,
+      goalMetrics,
+      guardrailMetrics,
+      requireSuperStatSig,
+    });
+
+    switch (outcome) {
+      case "not-matched":
+        continue;
+
+      case "indeterminate":
+        hasIndeterminateRule = true;
+        continue;
+
+      case "matched":
+        if (rule.action === "rollback" || !hasIndeterminateRule) {
+          return {
+            status: "decided",
+            variation: {
+              variationId: variation.variationId,
+              decidingRule: rule,
+            },
+            decisionCriteriaAction: rule.action,
+          };
+        }
+        return { status: "indeterminate", variation: undecided };
+    }
+  }
+
+  if (hasIndeterminateRule) {
+    return { status: "indeterminate", variation: undecided };
+  }
+
+  if (fallbackAction !== null) {
+    return {
+      status: "decided",
+      variation: undecided,
+      decisionCriteriaAction: fallbackAction,
+    };
+  }
+  return { status: "pending", variation: undecided };
 }
 
 // Get the decision for each variation based on the decision criteria
@@ -121,68 +236,22 @@ export function getVariationDecisions({
   powerReached: boolean;
   goalMetrics: string[];
   guardrailMetrics: string[];
-}): {
-  variation: DecisionFrameworkVariation;
-  decisionCriteriaAction: DecisionCriteriaAction | null;
-}[] {
-  const results: {
-    variation: DecisionFrameworkVariation;
-    decisionCriteriaAction: DecisionCriteriaAction | null;
-  }[] = [];
-
-  const { rules } = decisionCriteria;
-
-  resultsStatus.variations.forEach((variation) => {
-    let decisionReached = false;
-    for (const rule of rules) {
-      const action = evaluateDecisionRuleOnVariation({
-        rule,
-        variationStatus: variation,
-        goalMetrics,
-        guardrailMetrics,
-        requireSuperStatSig: false,
-      });
-      if (action) {
-        results.push({
-          variation: {
-            variationId: variation.variationId,
-            decidingRule: rule,
-          },
-          decisionCriteriaAction: action,
-        });
-        decisionReached = true;
-        break;
-      }
-    }
-    if (!decisionReached) {
-      // if no decision was reached and power was reached, return the default action
-      if (powerReached) {
-        results.push({
-          variation: {
-            variationId: variation.variationId,
-            decidingRule: null,
-          },
-          decisionCriteriaAction: decisionCriteria.defaultAction,
-        });
-      } else {
-        // if no decision was reached and power was not reached (sequential testing), return null
-        results.push({
-          variation: {
-            variationId: variation.variationId,
-            decidingRule: null,
-          },
-          decisionCriteriaAction: null,
-        });
-      }
-    }
-  });
-
-  return results;
+}): VariationDecision[] {
+  return resultsStatus.variations.map((variation) =>
+    decideVariation({
+      variation,
+      rules: decisionCriteria.rules,
+      goalMetrics,
+      guardrailMetrics,
+      requireSuperStatSig: false,
+      // Without power (sequential testing) an unmatched variation stays pending.
+      fallbackAction: powerReached ? decisionCriteria.defaultAction : null,
+    }),
+  );
 }
 
-// Early stopping decision criteria requires "super stat sig" status
-// and does not use the fallback action, instead preferring to render
-// no result
+// Early stopping requires "super stat sig" status and never falls back to the
+// default action: only stop early on an explicitly met rule.
 export function getEarlyStoppingVariationDecisions({
   resultsStatus,
   decisionCriteria,
@@ -193,55 +262,17 @@ export function getEarlyStoppingVariationDecisions({
   decisionCriteria: DecisionCriteriaData;
   goalMetrics: string[];
   guardrailMetrics: string[];
-}): {
-  variation: DecisionFrameworkVariation;
-  decisionCriteriaAction: DecisionCriteriaAction | null;
-}[] {
-  const results: {
-    variation: DecisionFrameworkVariation;
-    decisionCriteriaAction: DecisionCriteriaAction | null;
-  }[] = [];
-
-  const { rules } = decisionCriteria;
-
-  resultsStatus.variations.forEach((variation) => {
-    let decisionReached = false;
-    for (const rule of rules) {
-      const action = evaluateDecisionRuleOnVariation({
-        rule,
-        variationStatus: variation,
-        goalMetrics,
-        guardrailMetrics,
-        requireSuperStatSig: true,
-      });
-      if (action) {
-        results.push({
-          variation: {
-            variationId: variation.variationId,
-            decidingRule: rule,
-          },
-          decisionCriteriaAction: action,
-        });
-        decisionReached = true;
-        break;
-      }
-    }
-    // If no decision was reached, return null, ignoring the fallback
-    // action since we only want to prematurely stop if the experiment has
-    // met one of the explicitly stated criteria with a clear level of
-    // evidence
-    if (!decisionReached) {
-      results.push({
-        variation: {
-          variationId: variation.variationId,
-          decidingRule: null,
-        },
-        decisionCriteriaAction: null,
-      });
-    }
-  });
-
-  return results;
+}): VariationDecision[] {
+  return resultsStatus.variations.map((variation) =>
+    decideVariation({
+      variation,
+      rules: decisionCriteria.rules,
+      goalMetrics,
+      guardrailMetrics,
+      requireSuperStatSig: true,
+      fallbackAction: null,
+    }),
+  );
 }
 export function getHealthSettings(
   settings?: OrganizationSettings,
@@ -261,6 +292,30 @@ export function getHealthSettings(
   };
 }
 
+function getFailedMetricIds({
+  resultsStatus,
+  goalMetrics,
+  guardrailMetrics,
+}: {
+  resultsStatus: ExperimentAnalysisSummaryResultsStatus;
+  goalMetrics: string[];
+  guardrailMetrics: string[];
+}): string[] {
+  const failed = new Set<string>();
+  for (const variation of resultsStatus.variations) {
+    for (const m of goalMetrics) {
+      const goal = variation.goalMetrics?.[m];
+      if (goal?.status === "failed" || goal?.superStatSigStatus === "failed") {
+        failed.add(m);
+      }
+    }
+    for (const m of guardrailMetrics) {
+      if (variation.guardrailMetrics?.[m]?.status === "failed") failed.add(m);
+    }
+  }
+  return [...failed];
+}
+
 export function getDecisionFrameworkStatus({
   resultsStatus,
   decisionCriteria,
@@ -271,6 +326,8 @@ export function getDecisionFrameworkStatus({
 }: {
   resultsStatus: ExperimentAnalysisSummaryResultsStatus;
   decisionCriteria: DecisionCriteriaData;
+  // Member metric ids with any metric groups already expanded; resultsStatus
+  // is keyed by them.
   goalMetrics: string[];
   guardrailMetrics: string[];
   daysNeeded?: number;
@@ -305,6 +362,15 @@ export function getDecisionFrameworkStatus({
       : ""
   }`;
 
+  const dataIncomplete = (): ExperimentResultStatusData => ({
+    status: "data-incomplete",
+    failedMetrics: getFailedMetricIds({
+      resultsStatus,
+      goalMetrics,
+      guardrailMetrics,
+    }),
+  });
+
   if (decisionReady) {
     const variationDecisions = getVariationDecisions({
       resultsStatus,
@@ -316,7 +382,10 @@ export function getDecisionFrameworkStatus({
 
     const allRollbackNow =
       variationDecisions.length > 0 &&
-      variationDecisions.every((d) => d.decisionCriteriaAction === "rollback");
+      variationDecisions.every(
+        (d) =>
+          d.status === "decided" && d.decisionCriteriaAction === "rollback",
+      );
     if (allRollbackNow) {
       return {
         status: "rollback-now",
@@ -328,8 +397,12 @@ export function getDecisionFrameworkStatus({
       };
     }
 
+    if (variationDecisions.some((d) => d.status === "indeterminate")) {
+      return dataIncomplete();
+    }
+
     const shipVariations = variationDecisions.filter(
-      (d) => d.decisionCriteriaAction === "ship",
+      (d) => d.status === "decided" && d.decisionCriteriaAction === "ship",
     );
     if (shipVariations.length > 0) {
       return {
@@ -346,7 +419,7 @@ export function getDecisionFrameworkStatus({
     // sequential results
     if (powerReached || scheduledEndPassed) {
       const reviewVariations = variationDecisions.filter(
-        (d) => d.decisionCriteriaAction === "review",
+        (d) => d.status === "decided" && d.decisionCriteriaAction === "review",
       );
       if (reviewVariations.length > 0) {
         return {
@@ -374,7 +447,8 @@ export function getDecisionFrameworkStatus({
     const allRollbackNow =
       superStatSigVariationDecisions.length > 0 &&
       superStatSigVariationDecisions.every(
-        (d) => d.decisionCriteriaAction === "rollback",
+        (d) =>
+          d.status === "decided" && d.decisionCriteriaAction === "rollback",
       );
     if (allRollbackNow) {
       return {
@@ -389,6 +463,12 @@ export function getDecisionFrameworkStatus({
       };
     }
 
+    if (
+      superStatSigVariationDecisions.some((d) => d.status === "indeterminate")
+    ) {
+      return dataIncomplete();
+    }
+
     // Early stopping should only say ship if one variation is a clear winner
     // and all other variations are clearly not winners
     // So only early stop if you have met shipping criteria with stat sig
@@ -399,11 +479,11 @@ export function getDecisionFrameworkStatus({
     // if you have many arms, where it requires more logic to determine if you have
     // a clear winner
     const shipVariations = superStatSigVariationDecisions.filter(
-      (d) => d.decisionCriteriaAction === "ship",
+      (d) => d.status === "decided" && d.decisionCriteriaAction === "ship",
     );
     const onlyOneShip = shipVariations.length === 1;
     const numberOfRollbackVariations = superStatSigVariationDecisions.filter(
-      (d) => d.decisionCriteriaAction === "rollback",
+      (d) => d.status === "decided" && d.decisionCriteriaAction === "rollback",
     ).length;
 
     const restRollback =
@@ -441,10 +521,14 @@ export function getExperimentResultStatus({
   experimentData,
   healthSettings,
   decisionCriteria,
+  metricGroups,
 }: {
   experimentData: ExperimentDataForStatus | ExperimentDataForStatusStringDates;
   healthSettings: ExperimentHealthSettings;
   decisionCriteria: DecisionCriteriaData;
+  // Goal/guardrail lists may hold metric-group ids; resultsStatus is keyed by
+  // member id.
+  metricGroups: MetricGroupInterface[];
 }): ExperimentResultStatusData | undefined {
   const unhealthyData: ExperimentUnhealthyData = {};
   const healthSummary = experimentData.analysisSummary?.health;
@@ -493,15 +577,23 @@ export function getExperimentResultStatus({
         )
       : null;
 
+  const expandedGoalMetrics = expandMetricGroups(
+    experimentData.goalMetrics,
+    metricGroups,
+  );
+
   // Fully skip decision framework if there are no goal metrics
   // TODO @dmf-experiment: Add front-end information about this
   let decisionStatus: ExperimentResultStatusData | undefined = undefined;
-  if (experimentData.goalMetrics.length && resultsStatus) {
+  if (expandedGoalMetrics.length && resultsStatus) {
     decisionStatus = getDecisionFrameworkStatus({
       resultsStatus,
       decisionCriteria,
-      goalMetrics: experimentData.goalMetrics,
-      guardrailMetrics: experimentData.guardrailMetrics,
+      goalMetrics: expandedGoalMetrics,
+      guardrailMetrics: expandMetricGroups(
+        experimentData.guardrailMetrics,
+        metricGroups,
+      ),
       daysNeeded,
       scheduledEndPassed,
     });
@@ -622,7 +714,7 @@ export function getExperimentResultStatus({
   // 5. The scheduled end has passed but there is no recommendation. Explain why
   // and prompt a manual review. Not gated on the Decision Framework.
   if (scheduledEndPassed) {
-    const reason = !experimentData.goalMetrics.length
+    const reason = !expandedGoalMetrics.length
       ? "No goal metrics are configured, so no recommendation can be made."
       : !resultsStatus
         ? "Results are not available yet."
@@ -751,6 +843,7 @@ export function getSafeRolloutResultStatus({
         resultsStatus,
         decisionCriteria: ROLLBACK_SAFE_ROLLOUT_DECISION_CRITERIA,
         goalMetrics: [],
+        // Safe rollouts do not expand metric-group guardrails yet.
         guardrailMetrics: safeRollout.guardrailMetricIds,
         daysNeeded: Infinity, // sequential relied upon solely for safe rollouts
       })

--- a/packages/shared/src/enterprise/decision-criteria/decisionCriteria.ts
+++ b/packages/shared/src/enterprise/decision-criteria/decisionCriteria.ts
@@ -43,7 +43,7 @@ import {
 
 export type MatchResult = "matched" | "not-matched" | "indeterminate";
 
-// Failed metrics make a condition indeterminate unless known metrics decide it.
+// Errored metrics make a condition indeterminate unless known metrics decide it.
 function evaluateConditionMatch({
   values,
   desiredStatus,
@@ -53,27 +53,27 @@ function evaluateConditionMatch({
   desiredStatus: string;
   match: DecisionCriteriaCondition["match"];
 }): MatchResult {
-  const known = values.filter((v) => v !== "failed");
-  const anyFailed = values.some((v) => v === "failed");
+  const known = values.filter((v) => v !== "errored");
+  const anyErrored = values.some((v) => v === "errored");
 
   switch (match) {
     case "all":
       if (known.some((v) => v !== desiredStatus)) {
         return "not-matched";
       }
-      return anyFailed ? "indeterminate" : "matched";
+      return anyErrored ? "indeterminate" : "matched";
 
     case "any":
       if (known.some((v) => v === desiredStatus)) {
         return "matched";
       }
-      return anyFailed ? "indeterminate" : "not-matched";
+      return anyErrored ? "indeterminate" : "not-matched";
 
     case "none":
       if (known.some((v) => v === desiredStatus)) {
         return "not-matched";
       }
-      return anyFailed ? "indeterminate" : "matched";
+      return anyErrored ? "indeterminate" : "matched";
   }
 }
 
@@ -292,7 +292,7 @@ export function getHealthSettings(
   };
 }
 
-function getFailedMetricIds({
+function getErroredMetricIds({
   resultsStatus,
   goalMetrics,
   guardrailMetrics,
@@ -301,19 +301,22 @@ function getFailedMetricIds({
   goalMetrics: string[];
   guardrailMetrics: string[];
 }): string[] {
-  const failed = new Set<string>();
+  const errored = new Set<string>();
   for (const variation of resultsStatus.variations) {
     for (const m of goalMetrics) {
       const goal = variation.goalMetrics?.[m];
-      if (goal?.status === "failed" || goal?.superStatSigStatus === "failed") {
-        failed.add(m);
+      if (
+        goal?.status === "errored" ||
+        goal?.superStatSigStatus === "errored"
+      ) {
+        errored.add(m);
       }
     }
     for (const m of guardrailMetrics) {
-      if (variation.guardrailMetrics?.[m]?.status === "failed") failed.add(m);
+      if (variation.guardrailMetrics?.[m]?.status === "errored") errored.add(m);
     }
   }
-  return [...failed];
+  return [...errored];
 }
 
 export function getDecisionFrameworkStatus({
@@ -364,7 +367,7 @@ export function getDecisionFrameworkStatus({
 
   const dataIncomplete = (): ExperimentResultStatusData => ({
     status: "data-incomplete",
-    failedMetrics: getFailedMetricIds({
+    erroredMetrics: getErroredMetricIds({
       resultsStatus,
       goalMetrics,
       guardrailMetrics,

--- a/packages/shared/src/enterprise/decision-criteria/statusIndicatorData.ts
+++ b/packages/shared/src/enterprise/decision-criteria/statusIndicatorData.ts
@@ -5,7 +5,10 @@ import {
   ExperimentResultStatusData,
   ExperimentDataForStatus,
 } from "shared/types/experiment";
+import { MetricGroupInterface } from "shared/types/metric-groups";
 import { getExperimentResultStatus } from "./decisionCriteria";
+
+export type MetricNameResolver = (metricId: string) => string;
 
 export type StatusIndicatorData = {
   color: "amber" | "green" | "red" | "gold" | "indigo" | "gray" | "pink";
@@ -17,12 +20,22 @@ export type StatusIndicatorData = {
   sortOrder: number;
 };
 
-export function getStatusIndicatorData(
-  experimentData: ExperimentDataForStatus | ExperimentDataForStatusStringDates,
-  skipArchived: boolean,
-  healthSettings: ExperimentHealthSettings,
-  decisionCriteria: DecisionCriteriaData,
-): StatusIndicatorData {
+export function getStatusIndicatorData({
+  experimentData,
+  skipArchived,
+  healthSettings,
+  decisionCriteria,
+  metricGroups,
+  resolveMetricName,
+}: {
+  experimentData: ExperimentDataForStatus | ExperimentDataForStatusStringDates;
+  skipArchived: boolean;
+  healthSettings: ExperimentHealthSettings;
+  decisionCriteria: DecisionCriteriaData;
+  metricGroups: MetricGroupInterface[];
+  // Failed metric ids are shown as-is when omitted.
+  resolveMetricName?: MetricNameResolver;
+}): StatusIndicatorData {
   if (!skipArchived && experimentData.archived) {
     return {
       color: "gold",
@@ -51,9 +64,13 @@ export function getStatusIndicatorData(
       experimentData,
       healthSettings,
       decisionCriteria,
+      metricGroups,
     });
     if (runningStatusData) {
-      return getDetailedRunningStatusIndicatorData(runningStatusData);
+      return getDetailedRunningStatusIndicatorData(
+        runningStatusData,
+        resolveMetricName,
+      );
     }
 
     // 6. Otherwise, show running status
@@ -121,6 +138,7 @@ export function getStatusIndicatorData(
 
 function getDetailedRunningStatusIndicatorData(
   decisionData: ExperimentResultStatusData,
+  resolveMetricName?: MetricNameResolver,
 ): StatusIndicatorData {
   switch (decisionData.status) {
     case "rollback-now":
@@ -168,6 +186,22 @@ function getDetailedRunningStatusIndicatorData(
         needsAttention: true,
         sortOrder: 10,
       };
+    case "data-incomplete": {
+      const failedNames = decisionData.failedMetrics.map(
+        (id) => resolveMetricName?.(id) ?? id,
+      );
+      const subject = failedNames.length
+        ? failedNames.join(", ")
+        : "Some metrics";
+      return {
+        color: "amber",
+        status: "Running",
+        detailedStatus: "Data incomplete",
+        tooltip: `${subject} could not be computed, so ship and review recommendations are paused. Roll back recommendations still apply.`,
+        needsAttention: true,
+        sortOrder: 9.5,
+      };
+    }
     case "unhealthy":
       return {
         color: "amber",

--- a/packages/shared/src/enterprise/decision-criteria/statusIndicatorData.ts
+++ b/packages/shared/src/enterprise/decision-criteria/statusIndicatorData.ts
@@ -33,7 +33,7 @@ export function getStatusIndicatorData({
   healthSettings: ExperimentHealthSettings;
   decisionCriteria: DecisionCriteriaData;
   metricGroups: MetricGroupInterface[];
-  // Failed metric ids are shown as-is when omitted.
+  // Errored metric ids are shown as-is when omitted.
   resolveMetricName?: MetricNameResolver;
 }): StatusIndicatorData {
   if (!skipArchived && experimentData.archived) {
@@ -187,11 +187,11 @@ function getDetailedRunningStatusIndicatorData(
         sortOrder: 10,
       };
     case "data-incomplete": {
-      const failedNames = decisionData.failedMetrics.map(
+      const erroredNames = decisionData.erroredMetrics.map(
         (id) => resolveMetricName?.(id) ?? id,
       );
-      const subject = failedNames.length
-        ? failedNames.join(", ")
+      const subject = erroredNames.length
+        ? erroredNames.join(", ")
         : "Some metrics";
       return {
         color: "amber",

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -317,14 +317,14 @@ export type ExperimentAnalysisSummaryHealth = z.infer<
   typeof experimentAnalysisSummaryHealth
 >;
 
-export const goalMetricStatus = ["won", "lost", "neutral", "failed"] as const;
+export const goalMetricStatus = ["won", "lost", "neutral", "errored"] as const;
 export type GoalMetricStatus = (typeof goalMetricStatus)[number];
 
 export const guardrailMetricStatus = [
   "safe",
   "lost",
   "neutral",
-  "failed",
+  "errored",
 ] as const;
 export type GuardrailMetricStatus = (typeof guardrailMetricStatus)[number];
 

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -317,10 +317,15 @@ export type ExperimentAnalysisSummaryHealth = z.infer<
   typeof experimentAnalysisSummaryHealth
 >;
 
-export const goalMetricStatus = ["won", "lost", "neutral"] as const;
+export const goalMetricStatus = ["won", "lost", "neutral", "failed"] as const;
 export type GoalMetricStatus = (typeof goalMetricStatus)[number];
 
-export const guardrailMetricStatus = ["safe", "lost", "neutral"] as const;
+export const guardrailMetricStatus = [
+  "safe",
+  "lost",
+  "neutral",
+  "failed",
+] as const;
 export type GuardrailMetricStatus = (typeof guardrailMetricStatus)[number];
 
 export const goalMetricResult = z.object({

--- a/packages/shared/test/decisionCriteria.test.ts
+++ b/packages/shared/test/decisionCriteria.test.ts
@@ -2,6 +2,7 @@ import {
   ExperimentAnalysisSummaryResultsStatus,
   ExperimentAnalysisSummaryVariationStatus,
   DecisionCriteriaRule,
+  DecisionCriteriaData,
   ExperimentResultStatusData,
   ExperimentDataForStatus,
   ExperimentHealthSettings,
@@ -15,6 +16,7 @@ import {
   getExperimentResultStatus,
 } from "../src/enterprise/decision-criteria/decisionCriteria";
 import { PRESET_DECISION_CRITERIA } from "../src/enterprise/decision-criteria/constants";
+import { MetricGroupInterface } from "../types/metric-groups";
 
 function shipNow(variationIds: string[]): ExperimentResultStatusData {
   return {
@@ -442,7 +444,7 @@ describe("evaluateDecisionRuleOnVariation", () => {
       guardrailMetrics: [],
       requireSuperStatSig: false,
     });
-    expect(allWinning).toEqual("ship");
+    expect(allWinning).toEqual("matched");
 
     // One metric losing - should not match
     const oneLosing = evaluateDecisionRuleOnVariation({
@@ -458,7 +460,7 @@ describe("evaluateDecisionRuleOnVariation", () => {
       guardrailMetrics: [],
       requireSuperStatSig: false,
     });
-    expect(oneLosing).toBeUndefined();
+    expect(oneLosing).toEqual("not-matched");
   });
 
   it("evaluates goal metrics with 'any' match condition", () => {
@@ -487,7 +489,7 @@ describe("evaluateDecisionRuleOnVariation", () => {
       guardrailMetrics: [],
       requireSuperStatSig: false,
     });
-    expect(oneWinning).toEqual("ship");
+    expect(oneWinning).toEqual("matched");
 
     // No metrics winning - should not match
     const noneWinning = evaluateDecisionRuleOnVariation({
@@ -503,7 +505,7 @@ describe("evaluateDecisionRuleOnVariation", () => {
       guardrailMetrics: [],
       requireSuperStatSig: false,
     });
-    expect(noneWinning).toBeUndefined();
+    expect(noneWinning).toEqual("not-matched");
   });
 
   it("evaluates goal metrics with 'none' match condition", () => {
@@ -532,7 +534,7 @@ describe("evaluateDecisionRuleOnVariation", () => {
       guardrailMetrics: [],
       requireSuperStatSig: false,
     });
-    expect(noneLosing).toEqual("ship");
+    expect(noneLosing).toEqual("matched");
 
     // One metric losing - should not match
     const oneLosing = evaluateDecisionRuleOnVariation({
@@ -548,7 +550,7 @@ describe("evaluateDecisionRuleOnVariation", () => {
       guardrailMetrics: [],
       requireSuperStatSig: false,
     });
-    expect(oneLosing).toBeUndefined();
+    expect(oneLosing).toEqual("not-matched");
   });
 
   it("evaluates guardrail metrics correctly", () => {
@@ -564,7 +566,7 @@ describe("evaluateDecisionRuleOnVariation", () => {
     };
 
     // All guardrails losing - should match
-    const allWinning = evaluateDecisionRuleOnVariation({
+    const allLosing = evaluateDecisionRuleOnVariation({
       rule,
       variationStatus: {
         ...baseVariationStatus,
@@ -577,7 +579,7 @@ describe("evaluateDecisionRuleOnVariation", () => {
       guardrailMetrics: ["guardrail1", "guardrail2"],
       requireSuperStatSig: false,
     });
-    expect(allWinning).toEqual("rollback");
+    expect(allLosing).toEqual("matched");
 
     // One guardrail losing - should not match
     const oneLosing = evaluateDecisionRuleOnVariation({
@@ -593,7 +595,7 @@ describe("evaluateDecisionRuleOnVariation", () => {
       guardrailMetrics: ["guardrail1", "guardrail2"],
       requireSuperStatSig: false,
     });
-    expect(oneLosing).toBeUndefined();
+    expect(oneLosing).toEqual("not-matched");
   });
 
   it("respects requireSuperStatSig flag", () => {
@@ -621,7 +623,7 @@ describe("evaluateDecisionRuleOnVariation", () => {
       guardrailMetrics: [],
       requireSuperStatSig: true,
     });
-    expect(superStatSigRequired).toBeUndefined();
+    expect(superStatSigRequired).toEqual("not-matched");
 
     // With requireSuperStatSig=false, should check regular status
     const superStatSigNotRequired = evaluateDecisionRuleOnVariation({
@@ -636,7 +638,7 @@ describe("evaluateDecisionRuleOnVariation", () => {
       guardrailMetrics: [],
       requireSuperStatSig: false,
     });
-    expect(superStatSigNotRequired).toEqual("ship");
+    expect(superStatSigNotRequired).toEqual("matched");
   });
 
   it("handles multiple conditions", () => {
@@ -648,12 +650,12 @@ describe("evaluateDecisionRuleOnVariation", () => {
           direction: "statsigWinner" as const,
         },
         {
-          metrics: "guardrails" as const,
-          match: "none" as const,
-          direction: "statsigLoser" as const,
+          metrics: "guardrails",
+          match: "none",
+          direction: "statsigLoser",
         },
       ],
-      action: "ship" as const,
+      action: "ship",
     };
 
     // All conditions met - should match
@@ -672,7 +674,7 @@ describe("evaluateDecisionRuleOnVariation", () => {
       guardrailMetrics: ["guardrail1"],
       requireSuperStatSig: false,
     });
-    expect(allConditionsMet).toEqual("ship");
+    expect(allConditionsMet).toEqual("matched");
 
     // One condition not met - should not match
     const oneConditionNotMet = evaluateDecisionRuleOnVariation({
@@ -690,7 +692,73 @@ describe("evaluateDecisionRuleOnVariation", () => {
       guardrailMetrics: ["guardrail1"],
       requireSuperStatSig: false,
     });
-    expect(oneConditionNotMet).toBeUndefined();
+    expect(oneConditionNotMet).toEqual("not-matched");
+  });
+
+  it("returns not-matched when one condition is indeterminate and another does not match in either order", () => {
+    const indeterminateCondition: DecisionCriteriaRule["conditions"][number] = {
+      metrics: "guardrails",
+      match: "none",
+      direction: "statsigLoser",
+    };
+    const notMatchedCondition: DecisionCriteriaRule["conditions"][number] = {
+      metrics: "goals",
+      match: "all",
+      direction: "statsigWinner",
+    };
+
+    for (const conditions of [
+      [indeterminateCondition, notMatchedCondition],
+      [notMatchedCondition, indeterminateCondition],
+    ]) {
+      expect(
+        evaluateDecisionRuleOnVariation({
+          rule: { conditions, action: "ship" },
+          variationStatus: {
+            ...baseVariationStatus,
+            goalMetrics: {
+              goal1: { status: "lost", superStatSigStatus: "lost" },
+            },
+            guardrailMetrics: { guardrail1: { status: "failed" } },
+          },
+          goalMetrics: ["goal1"],
+          guardrailMetrics: ["guardrail1"],
+          requireSuperStatSig: false,
+        }),
+      ).toEqual("not-matched");
+    }
+  });
+
+  it("returns indeterminate when one condition is indeterminate and the rest match", () => {
+    expect(
+      evaluateDecisionRuleOnVariation({
+        rule: {
+          conditions: [
+            {
+              metrics: "guardrails",
+              match: "none",
+              direction: "statsigLoser",
+            },
+            {
+              metrics: "goals",
+              match: "all",
+              direction: "statsigWinner",
+            },
+          ],
+          action: "ship",
+        },
+        variationStatus: {
+          ...baseVariationStatus,
+          goalMetrics: {
+            goal1: { status: "won", superStatSigStatus: "won" },
+          },
+          guardrailMetrics: { guardrail1: { status: "failed" } },
+        },
+        goalMetrics: ["goal1"],
+        guardrailMetrics: ["guardrail1"],
+        requireSuperStatSig: false,
+      }),
+    ).toEqual("indeterminate");
   });
 });
 
@@ -711,7 +779,7 @@ describe("getVariationDecisions", () => {
     settings: { sequentialTesting: false },
   };
 
-  it("applies rules to each variation and returns default (no) action if no rules match and power is reached (not reached) ", () => {
+  it("returns a decided fallback with power and pending without power when no rules match", () => {
     const decisionCriteria = {
       id: "test-criteria-1",
       name: "Test Criteria 1",
@@ -740,16 +808,18 @@ describe("getVariationDecisions", () => {
 
     expect(results).toEqual([
       {
+        status: "decided",
         decisionCriteriaAction: "review",
         variation: { variationId: "1", decidingRule: null },
       },
       {
+        status: "decided",
         decisionCriteriaAction: "review",
         variation: { variationId: "2", decidingRule: null },
       },
     ]);
 
-    // without power, return null
+    // Without power, no fallback decision is available yet.
     const resultsWithoutPower = getVariationDecisions({
       resultsStatus: baseResultsStatus,
       decisionCriteria,
@@ -760,11 +830,11 @@ describe("getVariationDecisions", () => {
 
     expect(resultsWithoutPower).toEqual([
       {
-        decisionCriteriaAction: null,
+        status: "pending",
         variation: { variationId: "1", decidingRule: null },
       },
       {
-        decisionCriteriaAction: null,
+        status: "pending",
         variation: { variationId: "2", decidingRule: null },
       },
     ]);
@@ -798,10 +868,12 @@ describe("getVariationDecisions", () => {
 
     expect(results).toEqual([
       {
+        status: "decided",
         decisionCriteriaAction: "review",
         variation: { variationId: "1", decidingRule: null },
       },
       {
+        status: "decided",
         decisionCriteriaAction: "review",
         variation: { variationId: "2", decidingRule: null },
       },
@@ -865,10 +937,12 @@ describe("getVariationDecisions", () => {
 
     expect(results).toEqual([
       {
+        status: "decided",
         decisionCriteriaAction: "ship",
         variation: { variationId: "1", decidingRule: shipRule },
       },
       {
+        status: "decided",
         decisionCriteriaAction: "rollback",
         variation: { variationId: "2", decidingRule: rollbackRule },
       },
@@ -935,10 +1009,12 @@ describe("getVariationDecisions", () => {
     // Both variations match the first rule (any metric winning)
     expect(results).toEqual([
       {
+        status: "decided",
         decisionCriteriaAction: "ship",
         variation: { variationId: "1", decidingRule: shipRule },
       },
       {
+        status: "decided",
         decisionCriteriaAction: "ship",
         variation: { variationId: "2", decidingRule: shipRule },
       },
@@ -995,10 +1071,12 @@ describe("getVariationDecisions", () => {
 
     expect(results).toEqual([
       {
+        status: "decided",
         decisionCriteriaAction: "rollback",
         variation: { variationId: "1", decidingRule: rollbackRule },
       },
       {
+        status: "decided",
         decisionCriteriaAction: "review",
         variation: { variationId: "2", decidingRule: null },
       },
@@ -1050,12 +1128,13 @@ describe("getVariationDecisions", () => {
     });
 
     expect(results).toEqual([
-      // Should not go to fallback, should instead return null
+      // Early stopping has no fallback decision.
       {
-        decisionCriteriaAction: null,
+        status: "pending",
         variation: { variationId: "1", decidingRule: null },
       },
       {
+        status: "decided",
         decisionCriteriaAction: "ship",
         variation: { variationId: "2", decidingRule: shipRule },
       },
@@ -1313,6 +1392,395 @@ describe("resolveScheduledShipDecision", () => {
   });
 });
 
+describe("compute-failed metrics are indeterminate, not false", () => {
+  const baseVariationStatus: ExperimentAnalysisSummaryVariationStatus = {
+    variationId: "1",
+    goalMetrics: {},
+    guardrailMetrics: {},
+  };
+
+  it("returns 'indeterminate' for a match:'none' ship guardrail when a guardrail failed", () => {
+    const rule: DecisionCriteriaRule = {
+      conditions: [
+        {
+          metrics: "guardrails" as const,
+          match: "none" as const,
+          direction: "statsigLoser" as const,
+        },
+      ],
+      action: "ship" as const,
+    };
+
+    const result = evaluateDecisionRuleOnVariation({
+      rule,
+      variationStatus: {
+        ...baseVariationStatus,
+        guardrailMetrics: {
+          guardrail1: { status: "safe" },
+          guardrail2: { status: "failed" },
+        },
+      },
+      goalMetrics: [],
+      guardrailMetrics: ["guardrail1", "guardrail2"],
+      requireSuperStatSig: false,
+    });
+    expect(result).toEqual("indeterminate");
+  });
+
+  it("returns matched for match:'any' with a surviving winner despite another failing", () => {
+    const rule: DecisionCriteriaRule = {
+      conditions: [
+        {
+          metrics: "goals",
+          match: "any",
+          direction: "statsigWinner",
+        },
+      ],
+      action: "ship",
+    };
+
+    const result = evaluateDecisionRuleOnVariation({
+      rule,
+      variationStatus: {
+        ...baseVariationStatus,
+        goalMetrics: {
+          metric1: { status: "won", superStatSigStatus: "won" },
+          metric2: { status: "failed", superStatSigStatus: "failed" },
+        },
+      },
+      goalMetrics: ["metric1", "metric2"],
+      guardrailMetrics: [],
+      requireSuperStatSig: false,
+    });
+    expect(result).toEqual("matched");
+  });
+
+  it("returns not-matched for match:'all' with a surviving loser despite a failed metric", () => {
+    const rule: DecisionCriteriaRule = {
+      conditions: [
+        {
+          metrics: "goals",
+          match: "all",
+          direction: "statsigWinner",
+        },
+      ],
+      action: "ship",
+    };
+
+    const result = evaluateDecisionRuleOnVariation({
+      rule,
+      variationStatus: {
+        ...baseVariationStatus,
+        goalMetrics: {
+          metric1: { status: "lost", superStatSigStatus: "lost" },
+          metric2: { status: "failed", superStatSigStatus: "failed" },
+        },
+      },
+      goalMetrics: ["metric1", "metric2"],
+      guardrailMetrics: [],
+      requireSuperStatSig: false,
+    });
+    expect(result).toEqual("not-matched");
+  });
+
+  it("returns matched for a surviving losing guardrail while another failed", () => {
+    const rule: DecisionCriteriaRule = {
+      conditions: [
+        {
+          metrics: "guardrails",
+          match: "any",
+          direction: "statsigLoser",
+        },
+      ],
+      action: "rollback",
+    };
+
+    const result = evaluateDecisionRuleOnVariation({
+      rule,
+      variationStatus: {
+        ...baseVariationStatus,
+        guardrailMetrics: {
+          guardrail1: { status: "lost" },
+          guardrail2: { status: "failed" },
+        },
+      },
+      goalMetrics: [],
+      guardrailMetrics: ["guardrail1", "guardrail2"],
+      requireSuperStatSig: false,
+    });
+    expect(result).toEqual("matched");
+  });
+
+  it("rollback rule is indeterminate, not a no-match, when every guardrail failed", () => {
+    const rule: DecisionCriteriaRule = {
+      conditions: [
+        {
+          metrics: "guardrails",
+          match: "any",
+          direction: "statsigLoser",
+        },
+      ],
+      action: "rollback",
+    };
+
+    const result = evaluateDecisionRuleOnVariation({
+      rule,
+      variationStatus: {
+        ...baseVariationStatus,
+        guardrailMetrics: {
+          guardrail1: { status: "failed" },
+          guardrail2: { status: "failed" },
+        },
+      },
+      goalMetrics: [],
+      guardrailMetrics: ["guardrail1", "guardrail2"],
+      requireSuperStatSig: false,
+    });
+    expect(result).toEqual("indeterminate");
+  });
+
+  it("rollback match:'all' is indeterminate, not a vacuous match, when every guardrail failed", () => {
+    const rule: DecisionCriteriaRule = {
+      conditions: [
+        {
+          metrics: "guardrails",
+          match: "all",
+          direction: "statsigLoser",
+        },
+      ],
+      action: "rollback",
+    };
+
+    const result = evaluateDecisionRuleOnVariation({
+      rule,
+      variationStatus: {
+        ...baseVariationStatus,
+        guardrailMetrics: {
+          guardrail1: { status: "failed" },
+          guardrail2: { status: "failed" },
+        },
+      },
+      goalMetrics: [],
+      guardrailMetrics: ["guardrail1", "guardrail2"],
+      requireSuperStatSig: false,
+    });
+    expect(result).toEqual("indeterminate");
+  });
+
+  it("getDecisionFrameworkStatus yields data-incomplete when a ship goal metric failed", () => {
+    const resultsStatus: ExperimentAnalysisSummaryResultsStatus = {
+      variations: [
+        {
+          variationId: "1",
+          goalMetrics: {
+            metric1: { status: "failed", superStatSigStatus: "failed" },
+          },
+          guardrailMetrics: {},
+        },
+      ],
+      settings: { sequentialTesting: false },
+    };
+
+    const decision = getDecisionFrameworkStatus({
+      resultsStatus,
+      decisionCriteria: PRESET_DECISION_CRITERIA,
+      goalMetrics: ["metric1"],
+      guardrailMetrics: [],
+      daysNeeded: 0,
+    });
+
+    expect(decision).toEqual({
+      status: "data-incomplete",
+      failedMetrics: ["metric1"],
+    });
+  });
+
+  it("getDecisionFrameworkStatus still rolls back on a surviving losing guardrail while another failed", () => {
+    const resultsStatus: ExperimentAnalysisSummaryResultsStatus = {
+      variations: [
+        {
+          variationId: "1",
+          goalMetrics: {},
+          guardrailMetrics: {
+            guardrail1: { status: "lost" },
+            guardrail2: { status: "failed" },
+          },
+        },
+      ],
+      settings: { sequentialTesting: false },
+    };
+
+    const decision = getDecisionFrameworkStatus({
+      resultsStatus,
+      decisionCriteria: PRESET_DECISION_CRITERIA,
+      goalMetrics: [],
+      guardrailMetrics: ["guardrail1", "guardrail2"],
+      daysNeeded: 0,
+    });
+
+    expect(decision).toEqual({
+      status: "rollback-now",
+      variations: [
+        { variationId: "1", decidingRule: PRESET_DECISION_CRITERIA.rules[1] },
+      ],
+      sequentialUsed: false,
+      powerReached: true,
+      scheduledEndPassed: false,
+      tooltip: "The test variation(s) should be rolled back.",
+    });
+  });
+
+  it("does not fire a lower-precedence rollback when an indeterminate rule sits above a definitive ship/review", () => {
+    const criteria: DecisionCriteriaData = {
+      id: "gbdeccrit_ship_review_rollback",
+      name: "ship-review-rollback",
+      description: "",
+      rules: [
+        {
+          conditions: [
+            { metrics: "goals", match: "all", direction: "statsigWinner" },
+          ],
+          action: "ship",
+        },
+        {
+          conditions: [
+            { metrics: "goals", match: "any", direction: "statsigWinner" },
+          ],
+          action: "review",
+        },
+        {
+          conditions: [
+            { metrics: "guardrails", match: "any", direction: "statsigLoser" },
+          ],
+          action: "rollback",
+        },
+      ],
+      defaultAction: "review",
+    };
+
+    const resultsStatus: ExperimentAnalysisSummaryResultsStatus = {
+      variations: [
+        {
+          variationId: "1",
+          goalMetrics: {
+            goalA: { status: "won", superStatSigStatus: "won" },
+            goalB: { status: "failed", superStatSigStatus: "failed" },
+          },
+          guardrailMetrics: { guardrail1: { status: "lost" } },
+        },
+      ],
+      settings: { sequentialTesting: false },
+    };
+
+    const decision = getDecisionFrameworkStatus({
+      resultsStatus,
+      decisionCriteria: criteria,
+      goalMetrics: ["goalA", "goalB"],
+      guardrailMetrics: ["guardrail1"],
+      daysNeeded: 0,
+    });
+
+    expect(decision).toEqual({
+      status: "data-incomplete",
+      failedMetrics: ["goalB"],
+    });
+  });
+
+  it("withholds a lower ship rule when a higher rollback rule's only guardrail failed", () => {
+    const criteria: DecisionCriteriaData = {
+      id: "gbdeccrit_rollback_then_ship",
+      name: "rollback-then-ship",
+      description: "",
+      rules: [
+        {
+          conditions: [
+            { metrics: "guardrails", match: "any", direction: "statsigLoser" },
+          ],
+          action: "rollback",
+        },
+        {
+          conditions: [
+            { metrics: "goals", match: "all", direction: "statsigWinner" },
+          ],
+          action: "ship",
+        },
+      ],
+      defaultAction: "review",
+    };
+
+    const resultsStatus: ExperimentAnalysisSummaryResultsStatus = {
+      variations: [
+        {
+          variationId: "1",
+          goalMetrics: {
+            goalA: { status: "won", superStatSigStatus: "won" },
+          },
+          guardrailMetrics: { guardrail1: { status: "failed" } },
+        },
+      ],
+      settings: { sequentialTesting: false },
+    };
+
+    const decision = getDecisionFrameworkStatus({
+      resultsStatus,
+      decisionCriteria: criteria,
+      goalMetrics: ["goalA"],
+      guardrailMetrics: ["guardrail1"],
+      daysNeeded: 0,
+    });
+
+    expect(decision).toEqual({
+      status: "data-incomplete",
+      failedMetrics: ["guardrail1"],
+    });
+  });
+
+  it("getVariationDecisions marks an unresolved variation indeterminate with no action and no fallback", () => {
+    const results = getVariationDecisions({
+      resultsStatus: {
+        variations: [
+          {
+            variationId: "1",
+            goalMetrics: {
+              metric1: { status: "failed", superStatSigStatus: "failed" },
+            },
+            guardrailMetrics: {},
+          },
+          {
+            variationId: "2",
+            goalMetrics: {
+              metric1: { status: "won", superStatSigStatus: "won" },
+            },
+            guardrailMetrics: {},
+          },
+        ],
+        settings: { sequentialTesting: false },
+      },
+      decisionCriteria: PRESET_DECISION_CRITERIA,
+      goalMetrics: ["metric1"],
+      guardrailMetrics: [],
+      powerReached: true,
+    });
+
+    expect(results).toEqual([
+      {
+        status: "indeterminate",
+        variation: { variationId: "1", decidingRule: null },
+      },
+      {
+        status: "decided",
+        variation: {
+          variationId: "2",
+          decidingRule: PRESET_DECISION_CRITERIA.rules.find(
+            (r) => r.action === "ship",
+          ),
+        },
+        decisionCriteriaAction: "ship",
+      },
+    ]);
+  });
+});
+
 describe("getExperimentResultStatus schedule-driven states", () => {
   const baseHealthSettings: ExperimentHealthSettings = {
     decisionFrameworkEnabled: true,
@@ -1370,10 +1838,55 @@ describe("getExperimentResultStatus schedule-driven states", () => {
       }),
       healthSettings: baseHealthSettings,
       decisionCriteria: PRESET_DECISION_CRITERIA,
+      metricGroups: [],
     });
 
     expect(result?.status).toBe("scheduled-end-review");
     expect(result?.tooltip).toContain("The scheduled end date has passed");
+    expect(result?.tooltip).toContain("No goal metrics are configured");
+  });
+
+  it("requires review when the scheduled end passed with an empty goal metric group", () => {
+    const result = getExperimentResultStatus({
+      experimentData: makeExperimentData({
+        stopAt: daysAgo(1),
+        goalMetrics: ["mg_empty"],
+        analysisSummary: {
+          snapshotId: "snap-1",
+          health: { srm: 0.5, multipleExposures: 0, totalUsers: 1000 },
+          resultsStatus: {
+            variations: [
+              {
+                variationId: "1",
+                goalMetrics: {},
+                guardrailMetrics: {},
+              },
+            ],
+            settings: { sequentialTesting: false },
+          },
+        },
+      }),
+      healthSettings: baseHealthSettings,
+      decisionCriteria: PRESET_DECISION_CRITERIA,
+      metricGroups: [
+        {
+          id: "mg_empty",
+          organization: "org_1",
+          dateCreated: daysAgo(30),
+          dateUpdated: daysAgo(1),
+          name: "Empty goal group",
+          description: "",
+          owner: "",
+          tags: [],
+          projects: [],
+          metrics: [],
+          datasource: "ds_1",
+          archived: false,
+        },
+      ],
+    });
+
+    expect(result?.status).toBe("scheduled-end-review");
     expect(result?.tooltip).toContain("No goal metrics are configured");
   });
 
@@ -1392,6 +1905,7 @@ describe("getExperimentResultStatus schedule-driven states", () => {
       }),
       healthSettings: baseHealthSettings,
       decisionCriteria: PRESET_DECISION_CRITERIA,
+      metricGroups: [],
     });
 
     expect(result?.status).toBe("unhealthy");
@@ -1418,6 +1932,7 @@ describe("getExperimentResultStatus schedule-driven states", () => {
       }),
       healthSettings: baseHealthSettings,
       decisionCriteria: PRESET_DECISION_CRITERIA,
+      metricGroups: [],
     });
 
     expect(result?.status).toBe("days-left");
@@ -1445,6 +1960,7 @@ describe("getExperimentResultStatus schedule-driven states", () => {
       }),
       healthSettings: baseHealthSettings,
       decisionCriteria: PRESET_DECISION_CRITERIA,
+      metricGroups: [],
     });
 
     expect(result?.status).toBe("days-left");
@@ -1470,6 +1986,7 @@ describe("getExperimentResultStatus schedule-driven states", () => {
       }),
       healthSettings: baseHealthSettings,
       decisionCriteria: PRESET_DECISION_CRITERIA,
+      metricGroups: [],
     });
 
     expect(result).toMatchObject({ status: "days-left", daysLeft: 10 });
@@ -1484,9 +2001,85 @@ describe("getExperimentResultStatus schedule-driven states", () => {
         decisionFrameworkEnabled: false,
       },
       decisionCriteria: PRESET_DECISION_CRITERIA,
+      metricGroups: [],
     });
 
     expect(result).toMatchObject({ status: "days-left", daysLeft: 3 });
     expect(result?.tooltip).toContain("scheduled to end in about 3 days");
+  });
+
+  const incompleteAnalysisSummary: ExperimentDataForStatus["analysisSummary"] =
+    {
+      snapshotId: "snap-1",
+      health: {
+        srm: 0.5,
+        multipleExposures: 0,
+        totalUsers: 1000,
+        power: {
+          type: "success",
+          isLowPowered: false,
+          additionalDaysNeeded: 0,
+        },
+      },
+      resultsStatus: {
+        variations: [
+          {
+            variationId: "1",
+            goalMetrics: {
+              "metric-1": { status: "failed", superStatSigStatus: "failed" },
+            },
+            guardrailMetrics: {},
+          },
+        ],
+        settings: { sequentialTesting: false },
+      },
+    };
+
+  it("withholds data-incomplete while the experiment is before its minimum duration", () => {
+    const result = getExperimentResultStatus({
+      experimentData: makeExperimentData({
+        dateStarted: daysAgo(2),
+        analysisSummary: incompleteAnalysisSummary,
+      }),
+      healthSettings: baseHealthSettings,
+      decisionCriteria: PRESET_DECISION_CRITERIA,
+      metricGroups: [],
+    });
+
+    expect(result?.status).toBe("before-min-duration");
+  });
+
+  it("surfaces data-incomplete once the experiment is past its minimum duration", () => {
+    const result = getExperimentResultStatus({
+      experimentData: makeExperimentData({
+        dateStarted: daysAgo(30),
+        analysisSummary: incompleteAnalysisSummary,
+      }),
+      healthSettings: baseHealthSettings,
+      decisionCriteria: PRESET_DECISION_CRITERIA,
+      metricGroups: [],
+    });
+
+    expect(result?.status).toBe("data-incomplete");
+  });
+
+  it("expands metric groups so a failed group member is seen", () => {
+    const result = getExperimentResultStatus({
+      experimentData: makeExperimentData({
+        dateStarted: daysAgo(30),
+        goalMetrics: ["mg_1"],
+        analysisSummary: incompleteAnalysisSummary,
+      }),
+      healthSettings: baseHealthSettings,
+      decisionCriteria: PRESET_DECISION_CRITERIA,
+      metricGroups: [
+        { id: "mg_1", metrics: ["metric-1"] } as MetricGroupInterface,
+      ],
+    });
+
+    expect(result).toEqual({
+      status: "data-incomplete",
+      failedMetrics: ["metric-1"],
+    });
   });
 });

--- a/packages/shared/test/decisionCriteria.test.ts
+++ b/packages/shared/test/decisionCriteria.test.ts
@@ -57,7 +57,7 @@ function setMetricsOnResultsStatus({
   };
 }
 
-describe("getSafeRolloutResultStatus with failed guardrails", () => {
+describe("getSafeRolloutResultStatus with errored guardrails", () => {
   const healthSettings: ExperimentHealthSettings = {
     decisionFrameworkEnabled: true,
     experimentMinLengthDays: 7,
@@ -107,7 +107,7 @@ describe("getSafeRolloutResultStatus with failed guardrails", () => {
     (daysLeft) => {
       const result = getSafeRolloutResultStatus({
         safeRollout: makeSafeRollout({
-          failedGuardrail: { status: "failed" },
+          erroredGuardrail: { status: "errored" },
           safeGuardrail: { status: "safe" },
         }),
         healthSettings,
@@ -116,7 +116,7 @@ describe("getSafeRolloutResultStatus with failed guardrails", () => {
 
       expect(result).toEqual({
         status: "data-incomplete",
-        failedMetrics: ["failedGuardrail"],
+        erroredMetrics: ["erroredGuardrail"],
       });
     },
   );
@@ -134,10 +134,10 @@ describe("getSafeRolloutResultStatus with failed guardrails", () => {
     expect(result?.status).toBe(status);
   });
 
-  it("rolls back a losing guardrail even when another failed to compute", () => {
+  it("rolls back a losing guardrail even when another errored", () => {
     const result = getSafeRolloutResultStatus({
       safeRollout: makeSafeRollout({
-        failedGuardrail: { status: "failed" },
+        erroredGuardrail: { status: "errored" },
         losingGuardrail: { status: "lost" },
       }),
       healthSettings,
@@ -149,7 +149,7 @@ describe("getSafeRolloutResultStatus with failed guardrails", () => {
 
   it("keeps unhealthy status ahead of incomplete data", () => {
     const result = getSafeRolloutResultStatus({
-      safeRollout: makeSafeRollout({ guardrail: { status: "failed" } }, 0),
+      safeRollout: makeSafeRollout({ guardrail: { status: "errored" } }, 0),
       healthSettings,
       daysLeft: 0,
     });
@@ -825,7 +825,7 @@ describe("evaluateDecisionRuleOnVariation", () => {
             goalMetrics: {
               goal1: { status: "lost", superStatSigStatus: "lost" },
             },
-            guardrailMetrics: { guardrail1: { status: "failed" } },
+            guardrailMetrics: { guardrail1: { status: "errored" } },
           },
           goalMetrics: ["goal1"],
           guardrailMetrics: ["guardrail1"],
@@ -858,7 +858,7 @@ describe("evaluateDecisionRuleOnVariation", () => {
           goalMetrics: {
             goal1: { status: "won", superStatSigStatus: "won" },
           },
-          guardrailMetrics: { guardrail1: { status: "failed" } },
+          guardrailMetrics: { guardrail1: { status: "errored" } },
         },
         goalMetrics: ["goal1"],
         guardrailMetrics: ["guardrail1"],
@@ -1498,14 +1498,14 @@ describe("resolveScheduledShipDecision", () => {
   });
 });
 
-describe("compute-failed metrics are indeterminate, not false", () => {
+describe("computation errors make unresolved rules indeterminate", () => {
   const baseVariationStatus: ExperimentAnalysisSummaryVariationStatus = {
     variationId: "1",
     goalMetrics: {},
     guardrailMetrics: {},
   };
 
-  it("returns 'indeterminate' for a match:'none' ship guardrail when a guardrail failed", () => {
+  it("returns 'indeterminate' for a match:'none' ship guardrail when a guardrail errored", () => {
     const rule: DecisionCriteriaRule = {
       conditions: [
         {
@@ -1523,7 +1523,7 @@ describe("compute-failed metrics are indeterminate, not false", () => {
         ...baseVariationStatus,
         guardrailMetrics: {
           guardrail1: { status: "safe" },
-          guardrail2: { status: "failed" },
+          guardrail2: { status: "errored" },
         },
       },
       goalMetrics: [],
@@ -1533,7 +1533,7 @@ describe("compute-failed metrics are indeterminate, not false", () => {
     expect(result).toEqual("indeterminate");
   });
 
-  it("returns matched for match:'any' with a surviving winner despite another failing", () => {
+  it("returns matched for match:'any' with a surviving winner despite another errored metric", () => {
     const rule: DecisionCriteriaRule = {
       conditions: [
         {
@@ -1551,7 +1551,7 @@ describe("compute-failed metrics are indeterminate, not false", () => {
         ...baseVariationStatus,
         goalMetrics: {
           metric1: { status: "won", superStatSigStatus: "won" },
-          metric2: { status: "failed", superStatSigStatus: "failed" },
+          metric2: { status: "errored", superStatSigStatus: "errored" },
         },
       },
       goalMetrics: ["metric1", "metric2"],
@@ -1561,7 +1561,7 @@ describe("compute-failed metrics are indeterminate, not false", () => {
     expect(result).toEqual("matched");
   });
 
-  it("returns not-matched for match:'all' with a surviving loser despite a failed metric", () => {
+  it("returns not-matched for match:'all' with a surviving loser despite an errored metric", () => {
     const rule: DecisionCriteriaRule = {
       conditions: [
         {
@@ -1579,7 +1579,7 @@ describe("compute-failed metrics are indeterminate, not false", () => {
         ...baseVariationStatus,
         goalMetrics: {
           metric1: { status: "lost", superStatSigStatus: "lost" },
-          metric2: { status: "failed", superStatSigStatus: "failed" },
+          metric2: { status: "errored", superStatSigStatus: "errored" },
         },
       },
       goalMetrics: ["metric1", "metric2"],
@@ -1589,7 +1589,7 @@ describe("compute-failed metrics are indeterminate, not false", () => {
     expect(result).toEqual("not-matched");
   });
 
-  it("returns matched for a surviving losing guardrail while another failed", () => {
+  it("returns matched for a surviving losing guardrail while another errored", () => {
     const rule: DecisionCriteriaRule = {
       conditions: [
         {
@@ -1607,7 +1607,7 @@ describe("compute-failed metrics are indeterminate, not false", () => {
         ...baseVariationStatus,
         guardrailMetrics: {
           guardrail1: { status: "lost" },
-          guardrail2: { status: "failed" },
+          guardrail2: { status: "errored" },
         },
       },
       goalMetrics: [],
@@ -1617,7 +1617,7 @@ describe("compute-failed metrics are indeterminate, not false", () => {
     expect(result).toEqual("matched");
   });
 
-  it("rollback rule is indeterminate, not a no-match, when every guardrail failed", () => {
+  it("rollback rule is indeterminate, not a no-match, when every guardrail errored", () => {
     const rule: DecisionCriteriaRule = {
       conditions: [
         {
@@ -1634,8 +1634,8 @@ describe("compute-failed metrics are indeterminate, not false", () => {
       variationStatus: {
         ...baseVariationStatus,
         guardrailMetrics: {
-          guardrail1: { status: "failed" },
-          guardrail2: { status: "failed" },
+          guardrail1: { status: "errored" },
+          guardrail2: { status: "errored" },
         },
       },
       goalMetrics: [],
@@ -1645,7 +1645,7 @@ describe("compute-failed metrics are indeterminate, not false", () => {
     expect(result).toEqual("indeterminate");
   });
 
-  it("rollback match:'all' is indeterminate, not a vacuous match, when every guardrail failed", () => {
+  it("rollback match:'all' is indeterminate, not a vacuous match, when every guardrail errored", () => {
     const rule: DecisionCriteriaRule = {
       conditions: [
         {
@@ -1662,8 +1662,8 @@ describe("compute-failed metrics are indeterminate, not false", () => {
       variationStatus: {
         ...baseVariationStatus,
         guardrailMetrics: {
-          guardrail1: { status: "failed" },
-          guardrail2: { status: "failed" },
+          guardrail1: { status: "errored" },
+          guardrail2: { status: "errored" },
         },
       },
       goalMetrics: [],
@@ -1673,13 +1673,13 @@ describe("compute-failed metrics are indeterminate, not false", () => {
     expect(result).toEqual("indeterminate");
   });
 
-  it("getDecisionFrameworkStatus yields data-incomplete when a ship goal metric failed", () => {
+  it("getDecisionFrameworkStatus yields data-incomplete when a ship goal metric errored", () => {
     const resultsStatus: ExperimentAnalysisSummaryResultsStatus = {
       variations: [
         {
           variationId: "1",
           goalMetrics: {
-            metric1: { status: "failed", superStatSigStatus: "failed" },
+            metric1: { status: "errored", superStatSigStatus: "errored" },
           },
           guardrailMetrics: {},
         },
@@ -1697,11 +1697,11 @@ describe("compute-failed metrics are indeterminate, not false", () => {
 
     expect(decision).toEqual({
       status: "data-incomplete",
-      failedMetrics: ["metric1"],
+      erroredMetrics: ["metric1"],
     });
   });
 
-  it("getDecisionFrameworkStatus still rolls back on a surviving losing guardrail while another failed", () => {
+  it("getDecisionFrameworkStatus still rolls back on a surviving losing guardrail while another errored", () => {
     const resultsStatus: ExperimentAnalysisSummaryResultsStatus = {
       variations: [
         {
@@ -1709,7 +1709,7 @@ describe("compute-failed metrics are indeterminate, not false", () => {
           goalMetrics: {},
           guardrailMetrics: {
             guardrail1: { status: "lost" },
-            guardrail2: { status: "failed" },
+            guardrail2: { status: "errored" },
           },
         },
       ],
@@ -1770,7 +1770,7 @@ describe("compute-failed metrics are indeterminate, not false", () => {
           variationId: "1",
           goalMetrics: {
             goalA: { status: "won", superStatSigStatus: "won" },
-            goalB: { status: "failed", superStatSigStatus: "failed" },
+            goalB: { status: "errored", superStatSigStatus: "errored" },
           },
           guardrailMetrics: { guardrail1: { status: "lost" } },
         },
@@ -1788,11 +1788,11 @@ describe("compute-failed metrics are indeterminate, not false", () => {
 
     expect(decision).toEqual({
       status: "data-incomplete",
-      failedMetrics: ["goalB"],
+      erroredMetrics: ["goalB"],
     });
   });
 
-  it("withholds a lower ship rule when a higher rollback rule's only guardrail failed", () => {
+  it("withholds a lower ship rule when a higher rollback rule's only guardrail errored", () => {
     const criteria: DecisionCriteriaData = {
       id: "gbdeccrit_rollback_then_ship",
       name: "rollback-then-ship",
@@ -1821,7 +1821,7 @@ describe("compute-failed metrics are indeterminate, not false", () => {
           goalMetrics: {
             goalA: { status: "won", superStatSigStatus: "won" },
           },
-          guardrailMetrics: { guardrail1: { status: "failed" } },
+          guardrailMetrics: { guardrail1: { status: "errored" } },
         },
       ],
       settings: { sequentialTesting: false },
@@ -1837,7 +1837,7 @@ describe("compute-failed metrics are indeterminate, not false", () => {
 
     expect(decision).toEqual({
       status: "data-incomplete",
-      failedMetrics: ["guardrail1"],
+      erroredMetrics: ["guardrail1"],
     });
   });
 
@@ -1848,7 +1848,7 @@ describe("compute-failed metrics are indeterminate, not false", () => {
           {
             variationId: "1",
             goalMetrics: {
-              metric1: { status: "failed", superStatSigStatus: "failed" },
+              metric1: { status: "errored", superStatSigStatus: "errored" },
             },
             guardrailMetrics: {},
           },
@@ -2132,7 +2132,7 @@ describe("getExperimentResultStatus schedule-driven states", () => {
           {
             variationId: "1",
             goalMetrics: {
-              "metric-1": { status: "failed", superStatSigStatus: "failed" },
+              "metric-1": { status: "errored", superStatSigStatus: "errored" },
             },
             guardrailMetrics: {},
           },
@@ -2169,7 +2169,7 @@ describe("getExperimentResultStatus schedule-driven states", () => {
     expect(result?.status).toBe("data-incomplete");
   });
 
-  it("expands metric groups so a failed group member is seen", () => {
+  it("expands metric groups so an errored group member is seen", () => {
     const result = getExperimentResultStatus({
       experimentData: makeExperimentData({
         dateStarted: daysAgo(30),
@@ -2185,7 +2185,7 @@ describe("getExperimentResultStatus schedule-driven states", () => {
 
     expect(result).toEqual({
       status: "data-incomplete",
-      failedMetrics: ["metric-1"],
+      erroredMetrics: ["metric-1"],
     });
   });
 });

--- a/packages/shared/test/decisionCriteria.test.ts
+++ b/packages/shared/test/decisionCriteria.test.ts
@@ -14,9 +14,11 @@ import {
   getEarlyStoppingVariationDecisions,
   resolveScheduledShipDecision,
   getExperimentResultStatus,
+  getSafeRolloutResultStatus,
 } from "../src/enterprise/decision-criteria/decisionCriteria";
 import { PRESET_DECISION_CRITERIA } from "../src/enterprise/decision-criteria/constants";
 import { MetricGroupInterface } from "../types/metric-groups";
+import { SafeRolloutInterface } from "../types/safe-rollout";
 
 function shipNow(variationIds: string[]): ExperimentResultStatusData {
   return {
@@ -54,6 +56,110 @@ function setMetricsOnResultsStatus({
     ],
   };
 }
+
+describe("getSafeRolloutResultStatus with failed guardrails", () => {
+  const healthSettings: ExperimentHealthSettings = {
+    decisionFrameworkEnabled: true,
+    experimentMinLengthDays: 7,
+    srmThreshold: 0.001,
+    multipleExposureMinPercent: 0.01,
+  };
+
+  function makeSafeRollout(
+    guardrailMetrics: NonNullable<
+      ExperimentAnalysisSummaryVariationStatus["guardrailMetrics"]
+    >,
+    srm = 1,
+  ): SafeRolloutInterface {
+    return {
+      id: "sfr_test",
+      organization: "org_test",
+      dateCreated: new Date("2020-01-01"),
+      dateUpdated: new Date("2020-01-01"),
+      startedAt: new Date("2020-01-01"),
+      featureId: "feature_test",
+      datasourceId: "ds_test",
+      exposureQueryId: "exposure_test",
+      status: "running",
+      guardrailMetricIds: Object.keys(guardrailMetrics),
+      maxDuration: { amount: 7, unit: "days" },
+      autoRollback: true,
+      autoSnapshots: true,
+      rampUpSchedule: {
+        enabled: false,
+        step: 0,
+        steps: [],
+        rampUpCompleted: true,
+      },
+      analysisSummary: {
+        snapshotId: "snapshot_test",
+        health: { srm, totalUsers: 2000, multipleExposures: 0 },
+        resultsStatus: {
+          settings: { sequentialTesting: true },
+          variations: [{ variationId: "1", guardrailMetrics }],
+        },
+      },
+    };
+  }
+
+  it.each([2, 0, -1])(
+    "preserves incomplete data with %s days left",
+    (daysLeft) => {
+      const result = getSafeRolloutResultStatus({
+        safeRollout: makeSafeRollout({
+          failedGuardrail: { status: "failed" },
+          safeGuardrail: { status: "safe" },
+        }),
+        healthSettings,
+        daysLeft,
+      });
+
+      expect(result).toEqual({
+        status: "data-incomplete",
+        failedMetrics: ["failedGuardrail"],
+      });
+    },
+  );
+
+  it.each([
+    { daysLeft: 2, status: "days-left" },
+    { daysLeft: 0, status: "ship-now" },
+  ])("keeps healthy rollout status $status", ({ daysLeft, status }) => {
+    const result = getSafeRolloutResultStatus({
+      safeRollout: makeSafeRollout({ guardrail: { status: "safe" } }),
+      healthSettings,
+      daysLeft,
+    });
+
+    expect(result?.status).toBe(status);
+  });
+
+  it("rolls back a losing guardrail even when another failed to compute", () => {
+    const result = getSafeRolloutResultStatus({
+      safeRollout: makeSafeRollout({
+        failedGuardrail: { status: "failed" },
+        losingGuardrail: { status: "lost" },
+      }),
+      healthSettings,
+      daysLeft: 0,
+    });
+
+    expect(result?.status).toBe("rollback-now");
+  });
+
+  it("keeps unhealthy status ahead of incomplete data", () => {
+    const result = getSafeRolloutResultStatus({
+      safeRollout: makeSafeRollout({ guardrail: { status: "failed" } }, 0),
+      healthSettings,
+      daysLeft: 0,
+    });
+
+    expect(result).toEqual({
+      status: "unhealthy",
+      unhealthyData: { srm: true },
+    });
+  });
+});
 
 describe("default decision tree is correct", () => {
   const resultsStatus: ExperimentAnalysisSummaryResultsStatus = {

--- a/packages/shared/types/experiment.d.ts
+++ b/packages/shared/types/experiment.d.ts
@@ -96,7 +96,7 @@ export type ExperimentResultStatus =
   | DecisionFrameworkExperimentRecommendationStatus
   | { status: "no-data" }
   | { status: "unhealthy"; unhealthyData: ExperimentUnhealthyData }
-  | { status: "data-incomplete"; failedMetrics: string[] }
+  | { status: "data-incomplete"; erroredMetrics: string[] }
   | { status: "before-min-duration" }
   // The scheduled end date has passed but there is no decision recommendation
   // (e.g. no goal metrics, no results yet, or the Experiment Decision

--- a/packages/shared/types/experiment.d.ts
+++ b/packages/shared/types/experiment.d.ts
@@ -96,6 +96,7 @@ export type ExperimentResultStatus =
   | DecisionFrameworkExperimentRecommendationStatus
   | { status: "no-data" }
   | { status: "unhealthy"; unhealthyData: ExperimentUnhealthyData }
+  | { status: "data-incomplete"; failedMetrics: string[] }
   | { status: "before-min-duration" }
   // The scheduled end date has passed but there is no decision recommendation
   // (e.g. no goal metrics, no results yet, or the Experiment Decision


### PR DESCRIPTION
### Features and Changes

- Treat failed metric results as indeterminate when the remaining results cannot resolve a rule.
- Distinguish decided, pending, and indeterminate variation decisions while preserving rule order and fallback behavior.
- Add a "Data incomplete" status with failed metric names, explain it in the scheduled-end banner, and withhold unresolved ship/review recommendations.
- Expand experiment metric groups before evaluation and require review when an empty group leaves no goal metrics.
- Preserve incomplete safe-rollout status through expiry and show review guidance instead of shipping or collection messaging.

This is the consumer step. No producer emits `failed` yet, so the failed-metric paths remain inactive in production. Consumer support lands first so a failed guardrail cannot satisfy a `match: none` ship rule when the producer is enabled. A follow-up will emit `failed` and remove the persistence gate that currently leaves analysis summaries stale on compute failures. That staleness already exists on main.

### Testing

- 54 decision-criteria unit tests, including safe-rollout failures before and after expiry, rollback precedence, rule ordering, and empty metric groups.
- `pnpm lint:ci`, shared/frontend type-checks, and Prettier checks on changed files.
