### PR TITLE
fix(experiments): report partial snapshot success

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -16412,6 +16412,7 @@ paths:
                             enum:
                               - running
                               - success
+                              - partial-success
                               - error
                           error:
                             type: string
@@ -65327,6 +65328,7 @@ components:
           enum:
             - running
             - success
+            - partial-success
             - error
         snapshotError:
           description: Error message if snapshot failed

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -16412,6 +16412,7 @@ paths:
                             enum:
                               - running
                               - success
+                              - partial-success
                               - error
                           error:
                             type: string
@@ -65327,6 +65328,7 @@ components:
           enum:
             - running
             - success
+            - partial-success
             - error
         snapshotError:
           description: Error message if snapshot failed

--- a/packages/back-end/src/api/experiments/bulkResultSerialization.ts
+++ b/packages/back-end/src/api/experiments/bulkResultSerialization.ts
@@ -1,6 +1,6 @@
 import { isEqual } from "lodash";
 import { DEFAULT_STATS_ENGINE } from "shared/constants";
-import { isDefined } from "shared/util";
+import { analysisHasResults, isDefined } from "shared/util";
 import {
   ExperimentMetricInterface,
   getFunnelStepMetric,
@@ -140,7 +140,7 @@ function getDifferenceTypeVariants(
     .map((differenceType) =>
       analyses.find(
         (a) =>
-          a.status === "success" &&
+          analysisHasResults(a.status) &&
           isEqual(a.settings, { ...baseAnalysis.settings, differenceType }),
       ),
     )
@@ -262,7 +262,8 @@ export function toExperimentSnapshotBulkResultsApiInterface(
   metricsById: Map<string, ExperimentMetricInterface>,
 ): ApiExperimentBulkResult[] {
   const defaultAnalysis = snapshot.analyses[0];
-  if (!defaultAnalysis || defaultAnalysis.status !== "success") return [];
+  if (!defaultAnalysis || !analysisHasResults(defaultAnalysis.status))
+    return [];
 
   const phase = experiment.phases[snapshot.phase];
 
@@ -294,7 +295,7 @@ export function toExperimentSnapshotBulkResultsApiInterface(
     if (dimensionId === defaultDimensionId) continue;
     const dimensionBaseAnalysis = snapshot.analyses.find(
       (a) =>
-        a.status === "success" &&
+        analysisHasResults(a.status) &&
         isEqual(a.settings, {
           ...defaultAnalysis.settings,
           dimensions: [dimensionId],

--- a/packages/back-end/src/api/experiments/postExperimentSnapshot.ts
+++ b/packages/back-end/src/api/experiments/postExperimentSnapshot.ts
@@ -1,5 +1,6 @@
 import isEqual from "lodash/isEqual";
 import { postExperimentSnapshotValidator } from "shared/validators";
+import { analysisHasResults } from "shared/util";
 import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
 import { getLatestSuccessfulSnapshot } from "back-end/src/models/ExperimentSnapshotModel";
@@ -123,7 +124,7 @@ export const postExperimentSnapshot = createApiRequestHandler(
       plan.snapshot.analyses.every(({ settings }) =>
         latestDimensionSnapshot.analyses?.some(
           (analysis) =>
-            analysis.status === "success" &&
+            analysisHasResults(analysis.status) &&
             isEqual(analysis.settings, settings),
         ),
       )

--- a/packages/back-end/src/api/ramp-schedules/rampScheduleActions.ts
+++ b/packages/back-end/src/api/ramp-schedules/rampScheduleActions.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 import { v4 as uuidv4 } from "uuid";
-import { PermissionError, isRampScheduleServing } from "shared/util";
+import {
+  PermissionError,
+  analysisHasResults,
+  isRampScheduleServing,
+} from "shared/util";
 import {
   apiRampScheduleInterface,
   DEFAULT_NO_TRAFFIC_GRACE_PERIOD_HOURS,
@@ -1076,8 +1080,8 @@ export const getRampScheduleStatus = createApiRequestHandler({
 
       // Index per-metric deviation data from the first successful analysis,
       // "All" dimension (results[0]), treatment variation (index 1).
-      const snapshotAnalysis = snapshot?.analyses?.find(
-        (a) => a.status === "success",
+      const snapshotAnalysis = snapshot?.analyses?.find((a) =>
+        analysisHasResults(a.status),
       );
       const allDimResult = snapshotAnalysis?.results?.[0];
       const controlMetrics = allDimResult?.variations?.[0]?.metrics ?? {};

--- a/packages/back-end/src/api/reports/getReport.ts
+++ b/packages/back-end/src/api/reports/getReport.ts
@@ -1,4 +1,5 @@
 import { getReportValidator } from "shared/validators";
+import { snapshotHasResults } from "shared/util";
 import { getReportById } from "back-end/src/models/ReportModel";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
 import { findSnapshotById } from "back-end/src/models/ExperimentSnapshotModel";
@@ -37,7 +38,7 @@ export const getReport = createApiRequestHandler(getReportValidator)(async (
       req.context,
     );
 
-    if (snapshot?.status === "success" && experiment) {
+    if (snapshot && snapshotHasResults(snapshot.status) && experiment) {
       const metricsById = await getMetricMapForExperiment(
         req.context,
         experiment,

--- a/packages/back-end/src/api/reports/postReportRefresh.ts
+++ b/packages/back-end/src/api/reports/postReportRefresh.ts
@@ -1,4 +1,5 @@
 import { postReportRefreshValidator } from "shared/validators";
+import { snapshotHasResults } from "shared/util";
 import { getReportById, updateReport } from "back-end/src/models/ReportModel";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
 import { findSnapshotById } from "back-end/src/models/ExperimentSnapshotModel";
@@ -73,7 +74,7 @@ export const postReportRefresh = createApiRequestHandler(
       req.context,
     );
 
-    if (newSnapshot.status === "success" && experiment) {
+    if (snapshotHasResults(newSnapshot.status) && experiment) {
       const results = toSnapshotApiInterface(
         experiment,
         newSnapshot,

--- a/packages/back-end/src/api/reports/putReportMetadata.ts
+++ b/packages/back-end/src/api/reports/putReportMetadata.ts
@@ -1,4 +1,5 @@
 import { putReportMetadataValidator } from "shared/validators";
+import { snapshotHasResults } from "shared/util";
 import { ExperimentSnapshotReportInterface } from "shared/types/report";
 import { getReportById, updateReport } from "back-end/src/models/ReportModel";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
@@ -63,7 +64,7 @@ export const putReportMetadata = createApiRequestHandler(
     req.context,
   );
 
-  if (snapshot?.status === "success" && experiment) {
+  if (snapshot && snapshotHasResults(snapshot.status) && experiment) {
     const metricsById = await getMetricMapForExperiment(
       req.context,
       experiment,

--- a/packages/back-end/src/api/reports/putReportSettings.ts
+++ b/packages/back-end/src/api/reports/putReportSettings.ts
@@ -1,4 +1,5 @@
 import { putReportSettingsValidator } from "shared/validators";
+import { snapshotHasResults } from "shared/util";
 import { ExperimentSnapshotReportInterface } from "shared/types/report";
 import { getValidDate } from "shared/dates";
 import { getReportById, updateReport } from "back-end/src/models/ReportModel";
@@ -166,7 +167,7 @@ export const putReportSettings = createApiRequestHandler(
     req.context,
   );
 
-  if (snapshot?.status === "success" && experiment) {
+  if (snapshot && snapshotHasResults(snapshot.status) && experiment) {
     const metricsById = await getMetricMapForExperiment(
       req.context,
       experiment,

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -7,9 +7,11 @@ import {
   DashboardInterface,
 } from "shared/enterprise";
 import {
+  analysisIsDegraded,
   findAnalysisComputeFailure,
   getSnapshotAnalysis,
   isString,
+  snapshotHasResults,
 } from "shared/util";
 import {
   SnapshotType,
@@ -540,7 +542,7 @@ export async function updateSnapshot({
 
     const shouldUpdateExperimentAnalysisSummary =
       experimentSnapshot.type === "standard" &&
-      experimentSnapshot.status === "success" &&
+      snapshotHasResults(experimentSnapshot.status) &&
       findAnalysisComputeFailure(getSnapshotAnalysis(experimentSnapshot)) ===
         null;
 
@@ -651,7 +653,7 @@ export async function updateSnapshot({
   };
 
   if (
-    experimentSnapshot.status === "success" &&
+    snapshotHasResults(experimentSnapshot.status) &&
     // Only use main snapshots or those triggered automatically for dashboards
     experimentSnapshot.triggeredBy !== "manual-dashboard" &&
     (experimentSnapshot.triggeredBy === "update-dashboards" ||
@@ -672,6 +674,24 @@ export type AddOrUpdateSnapshotAnalysisParams = {
   id: string;
   analysis: ExperimentSnapshotAnalysis;
 };
+
+// Analyses can be added or recomputed after a snapshot has completed (eager
+// dimension analyses, ad-hoc analyses). A degraded one flips the parent from
+// success to partial-success so snapshot consumers see the failed metric. The
+// flip is one-directional on purpose: this writer only holds a stale copy of
+// the sibling analyses, so it cannot prove they are all clean, and two
+// concurrent writers could otherwise overwrite a fresh partial-success with
+// success. Recovery to success is the query runner's rollup on the next run.
+// A running/error snapshot is still owned by its query runner and is left
+// alone.
+function snapshotStatusUpdateForAnalysisWrite(
+  snapshot: Pick<ExperimentSnapshotInterface, "status">,
+  analysis: Pick<ExperimentSnapshotAnalysis, "status">,
+): Partial<Pick<ExperimentSnapshotInterface, "status">> {
+  return snapshot.status === "success" && analysisIsDegraded(analysis.status)
+    ? { status: "partial-success" }
+    : {};
+}
 
 export async function addOrUpdateSnapshotAnalysis(
   params: AddOrUpdateSnapshotAnalysisParams,
@@ -704,6 +724,10 @@ export async function addOrUpdateSnapshotAnalysis(
     ...analysis,
     analysisKey,
   };
+  const snapshotStatusUpdate = snapshotStatusUpdateForAnalysisWrite(
+    existingInterface,
+    analysis,
+  );
 
   // Write the analysis's chunk sub-path atomically. Scoped to
   // `data.<analysisKey>` so concurrent writers for other analyses never
@@ -742,7 +766,7 @@ export async function addOrUpdateSnapshotAnalysis(
     });
     const updateDoc: Record<string, unknown> = {
       $push: { analyses: strippedAnalysis },
-      $set: setOps,
+      $set: { ...setOps, ...snapshotStatusUpdate },
     };
     if (Object.keys(unsetOps).length) updateDoc.$unset = unsetOps;
     const pushRes = await ExperimentSnapshotModel.updateOne(
@@ -777,7 +801,11 @@ export async function addOrUpdateSnapshotAnalysis(
     clearAllMeta,
   });
   const updateDoc: Record<string, unknown> = {
-    $set: { "analyses.$": strippedAnalysis, ...setOps },
+    $set: {
+      "analyses.$": strippedAnalysis,
+      ...setOps,
+      ...snapshotStatusUpdate,
+    },
   };
   if (Object.keys(unsetOps).length) updateDoc.$unset = unsetOps;
   await ExperimentSnapshotModel.updateOne(
@@ -838,6 +866,10 @@ export async function updateSnapshotAnalysis({
     ...analysis,
     analysisKey,
   };
+  const snapshotStatusUpdate = snapshotStatusUpdateForAnalysisWrite(
+    existingInterface,
+    analysis,
+  );
 
   const hasResults = keyedAnalysis.results.length > 0;
   const { metaEntry } =
@@ -861,7 +893,11 @@ export async function updateSnapshotAnalysis({
     clearAllMeta,
   });
   const updateDoc: Record<string, unknown> = {
-    $set: { "analyses.$": strippedAnalysis, ...setOps },
+    $set: {
+      "analyses.$": strippedAnalysis,
+      ...setOps,
+      ...snapshotStatusUpdate,
+    },
   };
   if (Object.keys(unsetOps).length) updateDoc.$unset = unsetOps;
 
@@ -956,11 +992,12 @@ export async function findSnapshotsByExperiment(
     dateCreated: { $gte: dateStart, $lte: dateEnd },
     // `status` is derived at read time by migrateSnapshot, so snapshots
     // written before the field existed need the legacy results check too.
-    // Both branches pin `status` so the index below can bound them; without
-    // that, `status` stops being an equality match and the dateCreated range
-    // and sort fall out of the index.
+    // Both branches constrain `status` (an `$in` set, or its absence) so the
+    // index below can still bound them; without that, `status` stops being an
+    // indexable predicate and the dateCreated range and sort fall out of the
+    // index.
     $or: [
-      { status: "success" },
+      { status: { $in: ["success", "partial-success"] } },
       {
         status: { $exists: false },
         results: { $exists: true, $type: "array", $ne: [] },
@@ -1101,7 +1138,7 @@ export async function getLatestSuccessfulSnapshot({
   let all = await ExperimentSnapshotModel.find(
     {
       ...query,
-      status: "success",
+      status: { $in: ["success", "partial-success"] },
       ...(beforeSnapshot
         ? { dateCreated: { $lt: beforeSnapshot.dateCreated } }
         : {}),
@@ -1204,7 +1241,7 @@ export async function getLatestSnapshotStatus({
   const mostRecent = await ExperimentSnapshotModel.findOne(
     {
       ...query,
-      status: { $in: ["success", "running", "error"] },
+      status: { $in: ["success", "partial-success", "running", "error"] },
     },
     snapshotStatusProjection,
     { sort: { dateCreated: -1 } },
@@ -1260,7 +1297,7 @@ export async function getLatestSnapshotMultipleExperiments(
     ...(withResults
       ? {
           $or: [
-            { status: "success" },
+            { status: { $in: ["success", "partial-success"] } },
             // get old snapshots if status field is missing
             { results: { $exists: true, $type: "array", $ne: [] } },
           ],

--- a/packages/back-end/src/models/SafeRolloutSnapshotModel.ts
+++ b/packages/back-end/src/models/SafeRolloutSnapshotModel.ts
@@ -6,6 +6,7 @@ import {
 import {
   findAnalysisComputeFailure,
   getSafeRolloutSnapshotAnalysis,
+  snapshotHasResults,
 } from "shared/util";
 import { updateSafeRolloutTimeSeries } from "back-end/src/services/safeRolloutTimeSeries";
 import {
@@ -79,7 +80,9 @@ export class SafeRolloutSnapshotModel extends BaseClass {
       {
         ...query,
         status: {
-          $in: withResults ? ["success"] : ["success", "running", "error"],
+          $in: withResults
+            ? ["success", "partial-success"]
+            : ["success", "partial-success", "running", "error"],
         },
         ...(beforeSnapshot
           ? { dateCreated: { $lt: beforeSnapshot.dateCreated } }
@@ -111,9 +114,10 @@ export class SafeRolloutSnapshotModel extends BaseClass {
       latestSafeRolloutSnapshot === null ||
       latestSafeRolloutSnapshot?.id === updatedDoc.id;
 
+    // Rollout decisions require a summary without metric compute failures.
     if (
       isLatestSnapshot &&
-      updatedDoc.status === "success" &&
+      snapshotHasResults(updatedDoc.status) &&
       findAnalysisComputeFailure(getSafeRolloutSnapshotAnalysis(updatedDoc)) ===
         null
     ) {

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
@@ -5,6 +5,10 @@ import {
   isFactMetric,
   isRatioMetric,
 } from "shared/experiments";
+import {
+  analysisStatusFromResults,
+  snapshotStatusFromAnalyses,
+} from "shared/util";
 import { Dimension } from "shared/types/integrations";
 import { FactMetricInterface } from "shared/types/fact-table";
 import {
@@ -483,7 +487,7 @@ export class ExperimentIncrementalRefreshExploratoryQueryRunner extends QueryRun
       if (!analysis) return;
 
       analysis.results = results.dimensions || [];
-      analysis.status = "success";
+      analysis.status = analysisStatusFromResults(analysis.results);
       analysis.error = "";
 
       // TODO: do this once, not per analysis
@@ -557,7 +561,7 @@ export class ExperimentIncrementalRefreshExploratoryQueryRunner extends QueryRun
           ? "running"
           : status === "failed"
             ? "error"
-            : "success",
+            : snapshotStatusFromAnalyses(this.model.analyses),
     };
     await updateSnapshot({
       context: this.context,

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -24,7 +24,12 @@ import {
   ExperimentSnapshotSettings,
   SnapshotType,
 } from "shared/types/experiment-snapshot";
-import { buildUnitsQuerySettingsFromSnapshot } from "shared/util";
+import {
+  buildUnitsQuerySettingsFromSnapshot,
+  analysisStatusFromResults,
+  snapshotHasResults,
+  snapshotStatusFromAnalyses,
+} from "shared/util";
 import {
   ExperimentQueryMetadata,
   Queries,
@@ -1310,7 +1315,7 @@ export class ExperimentIncrementalRefreshQueryRunner extends QueryRunner<
       if (!analysis) return;
 
       analysis.results = results.dimensions || [];
-      analysis.status = "success";
+      analysis.status = analysisStatusFromResults(analysis.results);
       analysis.error = "";
 
       // TODO: do this once, not per analysis
@@ -1446,7 +1451,7 @@ export class ExperimentIncrementalRefreshQueryRunner extends QueryRunner<
         ? "running"
         : status === "failed"
           ? "error"
-          : "success";
+          : snapshotStatusFromAnalyses(this.model.analyses);
 
     const updates: Partial<ExperimentSnapshotInterface> = {
       queries,
@@ -1471,9 +1476,8 @@ export class ExperimentIncrementalRefreshQueryRunner extends QueryRunner<
     }
 
     // Release the incremental refresh lock on any terminal status
-    // TODO: Properly handle partially-succeeded status that also becomes terminal??
     if (snapshotStatus !== "running") {
-      if (snapshotStatus === "success") {
+      if (snapshotHasResults(snapshotStatus)) {
         await this.context.models.incrementalRefresh
           .updateByExperimentIdIfCurrentExecution(
             this.model.experiment,

--- a/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
@@ -8,7 +8,11 @@ import {
 } from "shared/experiments";
 import { FALLBACK_EXPERIMENT_MAX_LENGTH_DAYS } from "shared/constants";
 import { daysBetween } from "shared/dates";
-import { buildUnitsQuerySettingsFromSnapshot } from "shared/util";
+import {
+  buildUnitsQuerySettingsFromSnapshot,
+  analysisStatusFromResults,
+  snapshotStatusFromAnalyses,
+} from "shared/util";
 import { SegmentInterface } from "shared/types/segment";
 import {
   Dimension,
@@ -554,7 +558,7 @@ export class ExperimentResultsQueryRunner extends QueryRunner<
       if (!analysis) return;
 
       analysis.results = results.dimensions || [];
-      analysis.status = "success";
+      analysis.status = analysisStatusFromResults(analysis.results);
       analysis.error = "";
 
       // TODO: do this once, not per analysis
@@ -676,7 +680,7 @@ export class ExperimentResultsQueryRunner extends QueryRunner<
           ? "running"
           : status === "failed"
             ? "error"
-            : "success",
+            : snapshotStatusFromAnalyses(this.model.analyses),
     };
     await updateSnapshot({
       context: this.context,

--- a/packages/back-end/src/queryRunners/SafeRolloutResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/SafeRolloutResultsQueryRunner.ts
@@ -1,5 +1,9 @@
 import { UpdateProps } from "shared/types/base-model";
 import { ExperimentMetricInterface } from "shared/experiments";
+import {
+  analysisStatusFromResults,
+  snapshotStatusFromAnalyses,
+} from "shared/util";
 import { omit } from "lodash";
 import { ExperimentAggregateUnitsQueryResponseRows } from "shared/types/integrations";
 import { Queries, QueryStatus } from "shared/types/query";
@@ -96,7 +100,7 @@ export class SafeRolloutResultsQueryRunner extends QueryRunner<
       if (!analysis) return;
 
       analysis.results = results.dimensions || [];
-      analysis.status = "success";
+      analysis.status = analysisStatusFromResults(analysis.results);
       analysis.error = "";
 
       // TODO: do this once, not per analysis
@@ -174,7 +178,7 @@ export class SafeRolloutResultsQueryRunner extends QueryRunner<
           ? "running"
           : status === "failed"
             ? "error"
-            : "success",
+            : snapshotStatusFromAnalyses(this.model.analyses),
     };
     await this.context.models.safeRolloutSnapshots.updateById(
       this.model.id,

--- a/packages/back-end/src/services/experimentNotifications.ts
+++ b/packages/back-end/src/services/experimentNotifications.ts
@@ -1,4 +1,8 @@
-import { includeExperimentInPayload, getSnapshotAnalysis } from "shared/util";
+import {
+  includeExperimentInPayload,
+  getSnapshotAnalysis,
+  snapshotHasResults,
+} from "shared/util";
 import {
   expandMetricGroups,
   getMetricResultStatus,
@@ -349,7 +353,7 @@ export const notifyNoData = async ({
   // the default analysis returned no variation rows.
   const analysis = getSnapshotAnalysis(snapshot);
   const triggered =
-    snapshot.status === "success" &&
+    snapshotHasResults(snapshot.status) &&
     (analysis?.results?.[0]?.variations?.length ?? 0) === 0;
 
   await memoizeNotification({

--- a/packages/back-end/src/services/experimentUpdateExecutionLogger.ts
+++ b/packages/back-end/src/services/experimentUpdateExecutionLogger.ts
@@ -1,5 +1,6 @@
 import { DataSourceInterface } from "shared/types/datasource";
 import {
+  ExperimentSnapshotStatus,
   SnapshotQueryRunnerKind,
   SnapshotTriggeredBy,
   SnapshotType,
@@ -133,7 +134,7 @@ export class ExperimentUpdateExecutionLogger {
       snapshotStatus,
       error,
     }: {
-      snapshotStatus: "running" | "success" | "error";
+      snapshotStatus: ExperimentSnapshotStatus;
       error?: string;
     },
   ): void {

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -19,6 +19,7 @@ import {
 } from "shared/constants";
 import { getScopedSettings, ScopedSettings } from "shared/settings";
 import {
+  analysisStatusFromResults,
   autoMerge,
   draftHasChangesOutsideTargetRef,
   DRAFT_REVISION_STATUSES,
@@ -2842,7 +2843,7 @@ export async function createSnapshotAnalysis(
     metricMap: metricMap,
   });
   analysis.results = results[0]?.dimensions || [];
-  analysis.status = "success";
+  analysis.status = analysisStatusFromResults(analysis.results);
   analysis.error = undefined;
 
   await updateSnapshotAnalysis({
@@ -2911,12 +2912,15 @@ export async function createSnapshotAnalysesBatched(
       metricMap,
     });
 
-    completedAnalyses = analyses.map((analysis, i) => ({
-      ...analysis,
-      results: results[i]?.dimensions ?? [],
-      status: "success" as const,
-      error: undefined,
-    }));
+    completedAnalyses = analyses.map((analysis, i) => {
+      const dimensions = results[i]?.dimensions ?? [];
+      return {
+        ...analysis,
+        results: dimensions,
+        status: analysisStatusFromResults(dimensions),
+        error: undefined,
+      };
+    });
   } catch (e) {
     const error = e instanceof Error ? e.message : String(e);
     completedAnalyses = analyses.map((analysis) => ({

--- a/packages/back-end/src/services/rampScheduleEvaluator.ts
+++ b/packages/back-end/src/services/rampScheduleEvaluator.ts
@@ -9,6 +9,7 @@ import { getSRMHealthData, getMultipleExposureHealthData } from "shared/health";
 import {
   findAnalysisComputeFailure,
   getSafeRolloutSnapshotAnalysis,
+  snapshotHasResults,
 } from "shared/util";
 import {
   DEFAULT_SRM_MINIMINUM_COUNT_PER_VARIATION,
@@ -212,7 +213,8 @@ async function evaluateMonitoredStep(
     safeRollout.analysisStartedAt ?? safeRollout.startedAt ?? null;
   const hasCurrentAnalysis =
     !!requiredSnapshotAt &&
-    summarySnapshot?.status === "success" &&
+    !!summarySnapshot &&
+    snapshotHasResults(summarySnapshot.status) &&
     summarySnapshot.dateCreated >= requiredSnapshotAt &&
     (!analysisFloor || summarySnapshot.dateCreated >= analysisFloor);
 

--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -7,7 +7,11 @@ import {
   EXPOSURE_DATE_DIMENSION_NAME,
 } from "shared/constants";
 
-import { parseEnvInt, putBaselineVariationFirst } from "shared/util";
+import {
+  analysisStatusFromResults,
+  parseEnvInt,
+  putBaselineVariationFirst,
+} from "shared/util";
 import {
   ExperimentMetricInterface,
   eligibleForUncappedMetric,
@@ -729,7 +733,7 @@ export async function writeSnapshotAnalyses(
         });
 
       analysisObj.results = experimentReportResults[0]?.dimensions || [];
-      analysisObj.status = "success";
+      analysisObj.status = analysisStatusFromResults(analysisObj.results);
       analysisObj.error = undefined;
     }
 

--- a/packages/back-end/test/models/ExperimentSnapshotModel.test.ts
+++ b/packages/back-end/test/models/ExperimentSnapshotModel.test.ts
@@ -1254,6 +1254,100 @@ describe("ExperimentSnapshotModel", () => {
       ).toBe(30);
     });
 
+    it("rolls a completed snapshot up to partial-success for a partial ad-hoc analysis", async () => {
+      const context = getSnapshotUpdateContext();
+      const snapshot = makeSnapshotWithMetric("snp_partial_ad_hoc_analysis");
+      const relativeSettings = makeAnalysisSettings({
+        differenceType: "relative",
+      });
+      const scaledSettings = makeAnalysisSettings({
+        differenceType: "scaled",
+      });
+
+      await createExperimentSnapshotModel({ data: snapshot, context });
+      await updateSnapshot({
+        context,
+        id: snapshot.id,
+        updates: {
+          status: "success",
+          analyses: [makeAnalysis({ settings: relativeSettings, value: 10 })],
+        },
+      });
+
+      await addOrUpdateSnapshotAnalysis({
+        context,
+        id: snapshot.id,
+        analysis: makeAnalysis({
+          settings: scaledSettings,
+          value: 20,
+          status: "partial",
+        }),
+      });
+
+      const result = await findSnapshotById(context, snapshot.id);
+      expect(result?.status).toBe("partial-success");
+      expect(
+        result?.analyses.find((a) => a.settings.differenceType === "scaled")
+          ?.status,
+      ).toBe("partial");
+    });
+
+    it("keeps partial-success when a partial analysis is recomputed cleanly", async () => {
+      const context = getSnapshotUpdateContext();
+      const snapshot = makeSnapshotWithMetric(
+        "snp_recomputed_partial_analysis",
+      );
+      const settings = makeAnalysisSettings();
+
+      await createExperimentSnapshotModel({ data: snapshot, context });
+      await updateSnapshot({
+        context,
+        id: snapshot.id,
+        updates: {
+          status: "partial-success",
+          analyses: [makeAnalysis({ settings, value: 10, status: "partial" })],
+        },
+      });
+
+      await updateSnapshotAnalysis({
+        context,
+        id: snapshot.id,
+        analysis: makeAnalysis({ settings, value: 20 }),
+      });
+
+      // The writer cannot prove sibling analyses are clean from its stale read,
+      // so recovery to success is left to the query runner's rollup.
+      const result = await findSnapshotById(context, snapshot.id);
+      expect(result?.status).toBe("partial-success");
+      expect(result?.analyses[0].status).toBe("success");
+    });
+
+    it("leaves a running snapshot's status to its query runner", async () => {
+      const context = getSnapshotUpdateContext();
+      const snapshot = makeSnapshotWithMetric("snp_running_partial_analysis");
+      const settings = makeAnalysisSettings();
+
+      await createExperimentSnapshotModel({ data: snapshot, context });
+      await updateSnapshot({
+        context,
+        id: snapshot.id,
+        updates: {
+          status: "running",
+          analyses: [makeAnalysis({ settings, value: 10, status: "running" })],
+        },
+      });
+
+      await updateSnapshotAnalysis({
+        context,
+        id: snapshot.id,
+        analysis: makeAnalysis({ settings, value: 20, status: "partial" }),
+      });
+
+      const result = await findSnapshotById(context, snapshot.id);
+      expect(result?.status).toBe("running");
+      expect(result?.analyses[0].status).toBe("partial");
+    });
+
     it("skips chunk rewrites for a new empty running analysis", async () => {
       const context = getSnapshotUpdateContext();
       const snapshot = makeSnapshotWithMetric("snp_new_empty_analysis");

--- a/packages/front-end/components/Experiment/SnapshotProvider.tsx
+++ b/packages/front-end/components/Experiment/SnapshotProvider.tsx
@@ -17,7 +17,7 @@ import {
   getExperimentSourceSnapshotRef,
   SourceSnapshotRef,
 } from "shared/enterprise";
-import { getSnapshotAnalysis } from "shared/util";
+import { getSnapshotAnalysis, snapshotHasResults } from "shared/util";
 import useApi from "@/hooks/useApi";
 import { useAuth } from "@/services/auth";
 
@@ -146,38 +146,35 @@ export function getPrecomputedUnitDimensionIds(
   return [];
 }
 
-// When the cheap status endpoint reports a newer successful snapshot than the
+// When the cheap status endpoint reports a newer results-bearing snapshot than the
 // one currently held by the heavy fetch, pull the fresh analyses exactly
 // once. This is what lets poll loops use a status-only mutator: the provider
 // handles upgrading to the full snapshot on completion, on background
 // completion seen via focus revalidation, etc. The single id-mismatch check
 // covers both "no heavy snapshot yet" (undefined !== id) and "heavy is behind
-// a newer successful run" (X !== Y). `heavyIsValidating` suppresses the
+// a newer results-bearing run" (X !== Y). `heavyIsValidating` suppresses the
 // initial-mount redundant refetch: on first load the heavy fetch is already
 // in flight while the status fetch resolves, and without this guard a status
 // response that lands outside SWR's dedup window would trigger a second
 // round-trip for a request the provider is already making.
-function useRefetchHeavyOnStatusSuccess(
+function useRefetchHeavyOnStatusResults(
   statusLatest: SnapshotStatusSummary | undefined,
   snapshotId: string | undefined,
   heavyIsValidating: boolean,
   refetchHeavy: () => Promise<unknown>,
 ): void {
+  const latestId = statusLatest?.id;
+  const latestStatus = statusLatest?.status;
+
   useEffect(() => {
-    if (statusLatest?.status !== "success") return;
+    if (latestStatus === undefined || !snapshotHasResults(latestStatus)) return;
     if (heavyIsValidating) return;
-    if (statusLatest.id !== snapshotId) void refetchHeavy();
-  }, [
-    statusLatest?.id,
-    statusLatest?.status,
-    snapshotId,
-    heavyIsValidating,
-    refetchHeavy,
-  ]);
+    if (latestId !== snapshotId) void refetchHeavy();
+  }, [latestId, latestStatus, snapshotId, heavyIsValidating, refetchHeavy]);
 }
 
 // Surfaces the status endpoint's view atomically with the heavy snapshot.
-// While the status endpoint reports a newer successful snapshot than the
+// While the status endpoint reports a newer results-bearing snapshot than the
 // heavy fetch has caught up to, hold back the visible value so consumers
 // don't see "queries done" alongside stale analyses for the duration of the
 // heavy refetch. Running / errored / progress updates pass through
@@ -191,7 +188,7 @@ function useCoherentLatest(
 ): SnapshotStatusSummary | undefined {
   const heavyAgrees =
     !statusLatest ||
-    statusLatest.status !== "success" ||
+    !snapshotHasResults(statusLatest.status) ||
     statusLatest.id === snapshotId;
   const [held, setHeld] = useState<SnapshotStatusSummary | undefined>(
     undefined,
@@ -269,7 +266,7 @@ export default function SnapshotProvider({
 
   const statusLatest = statusData?.latest ?? undefined;
   const snapshotId = data?.snapshot?.id;
-  useRefetchHeavyOnStatusSuccess(
+  useRefetchHeavyOnStatusResults(
     statusLatest,
     snapshotId,
     isValidating,

--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
@@ -31,7 +31,7 @@ import {
   OVERALL_NON_INCREMENTAL_FULL_REFRESH_REASON,
   IncrementalFullRefreshComparable,
 } from "shared/enterprise";
-import { getSnapshotAnalysis } from "shared/util";
+import { getSnapshotAnalysis, snapshotHasResults } from "shared/util";
 import { MetricGroupInterface } from "shared/types/metric-groups";
 import { getValidDate } from "shared/dates";
 import {
@@ -183,18 +183,21 @@ export default function AnalysisSettingsSummary({
   } = useSnapshot();
 
   // Track previous latest status to detect transition from "running" to "success"
-  const previousLatestStatusRef = useRef<string | undefined>(latest?.status);
+  const latestStatus = latest?.status;
+  const previousLatestStatusRef = useRef<string | undefined>(latestStatus);
 
-  // Call reset when latest status transitions from "running" to "success"
+  // Call reset when latest status transitions from "running" to a
+  // results-bearing status
   useEffect(() => {
     if (
       previousLatestStatusRef.current === "running" &&
-      latest?.status === "success"
+      latestStatus !== undefined &&
+      snapshotHasResults(latestStatus)
     ) {
       onSnapshotSuccessfulUpdate?.();
     }
-    previousLatestStatusRef.current = latest?.status;
-  }, [latest?.status, onSnapshotSuccessfulUpdate]);
+    previousLatestStatusRef.current = latestStatus;
+  }, [latestStatus, onSnapshotSuccessfulUpdate]);
 
   const hasData = (analysis?.results?.[0]?.variations?.length ?? 0) > 0;
   const hasValidStatsEngine =

--- a/packages/front-end/components/HomePage/ExperimentImpact/index.tsx
+++ b/packages/front-end/components/HomePage/ExperimentImpact/index.tsx
@@ -5,7 +5,7 @@ import { useForm } from "react-hook-form";
 import { ExperimentInterfaceStringDates } from "shared/types/experiment";
 import { datetime, getValidDate } from "shared/dates";
 import { ExperimentSnapshotInterface } from "shared/types/experiment-snapshot";
-import { getSnapshotAnalysis } from "shared/util";
+import { analysisHasResults, getSnapshotAnalysis } from "shared/util";
 import { getAllMetricIdsFromExperiment } from "shared/experiments";
 import { useAuth } from "@/services/auth";
 import useOrgSettings from "@/hooks/useOrgSettings";
@@ -222,7 +222,7 @@ export function scaleImpactAndSetMissingExperiments({
             }
           });
         } else {
-          if (defaultAnalysis && defaultAnalysis.status === "success") {
+          if (defaultAnalysis && analysisHasResults(defaultAnalysis.status)) {
             ei.error =
               "No snapshot with scaled impact available. Click calculate button above.";
             experimentsWithNoImpact.push(e.id);

--- a/packages/front-end/components/MetricExperiments/MetricExperiments.tsx
+++ b/packages/front-end/components/MetricExperiments/MetricExperiments.tsx
@@ -10,6 +10,7 @@ import {
   isFactMetric,
 } from "shared/experiments";
 import { DifferenceType, StatsEngine } from "shared/types/stats";
+import { snapshotHasResults } from "shared/util";
 import {
   ExperimentWithSnapshot,
   SnapshotMetric,
@@ -461,7 +462,9 @@ const MetricExperiments: FC<MetricAnalysisProps> = ({
         ? e.type === "multi-armed-bandit"
         : e.type !== "multi-armed-bandit") &&
       (includeOnlyResults
-        ? e.status !== "draft" && e.snapshot?.status === "success"
+        ? e.status !== "draft" &&
+          e.snapshot &&
+          snapshotHasResults(e.snapshot.status)
         : true),
   );
 

--- a/packages/shared/src/snapshot-analysis-chunks.ts
+++ b/packages/shared/src/snapshot-analysis-chunks.ts
@@ -2,6 +2,7 @@ import uniqid from "uniqid";
 import {
   ExperimentSnapshotAnalysis,
   ExperimentSnapshotAnalysisSettings,
+  ExperimentSnapshotAnalysisStatus,
   SnapshotMetric,
   SnapshotVariation,
 } from "shared/types/experiment-snapshot";
@@ -188,7 +189,7 @@ export interface AnalysisMetadata {
   analysisKey: string;
   settings: ExperimentSnapshotAnalysisSettings;
   dateCreated: Date;
-  status: "running" | "success" | "error";
+  status: ExperimentSnapshotAnalysisStatus;
   error?: string;
 }
 

--- a/packages/shared/src/util/index.ts
+++ b/packages/shared/src/util/index.ts
@@ -8,11 +8,16 @@ import {
 import {
   ExperimentSnapshotAnalysis,
   ExperimentSnapshotAnalysisSettings,
+  ExperimentSnapshotAnalysisStatus,
   ExperimentSnapshotInterface,
   ExperimentSnapshotSettings,
+  ExperimentSnapshotStatus,
 } from "shared/types/experiment-snapshot";
 import { FeatureInterface, FeatureRule } from "shared/types/feature";
-import { ExperimentReportVariation } from "shared/types/report";
+import {
+  ExperimentReportResultDimension,
+  ExperimentReportVariation,
+} from "shared/types/report";
 import { FeatureRevisionInterface } from "shared/types/feature-revision";
 import { Environment } from "shared/types/organization";
 import { VisualChange } from "shared/types/visual-changeset";
@@ -139,6 +144,75 @@ export function findAnalysisComputeFailure(
     }
   }
   return null;
+}
+
+// Compute failures are per metric, so an analysis whose results carry one is
+// "partial" rather than "success". Fresh results from the stats engine always
+// carry every field the types declare, so no legacy fallbacks here.
+export function analysisStatusFromResults(
+  results: ExperimentReportResultDimension[],
+): "success" | "partial" {
+  const anyComputeFailed = results.some((dimension) =>
+    dimension.variations.some((variation) =>
+      Object.values(variation.metrics).some((metric) => metric.computeFailed),
+    ),
+  );
+  return anyComputeFailed ? "partial" : "success";
+}
+
+export function analysisIsDegraded(
+  status: ExperimentSnapshotAnalysisStatus,
+): boolean {
+  switch (status) {
+    case "partial":
+    case "error":
+      return true;
+    case "success":
+    case "running":
+      return false;
+    default:
+      status satisfies never;
+      return false;
+  }
+}
+
+// A degraded analysis makes an otherwise successful snapshot partial.
+export function snapshotStatusFromAnalyses(
+  analyses: Pick<ExperimentSnapshotAnalysis, "status">[],
+): "success" | "partial-success" {
+  return analyses.some((a) => analysisIsDegraded(a.status))
+    ? "partial-success"
+    : "success";
+}
+
+export function snapshotHasResults(status: ExperimentSnapshotStatus): boolean {
+  switch (status) {
+    case "success":
+    case "partial-success":
+      return true;
+    case "running":
+    case "error":
+      return false;
+    default:
+      status satisfies never;
+      return false;
+  }
+}
+
+export function analysisHasResults(
+  status: ExperimentSnapshotAnalysisStatus,
+): boolean {
+  switch (status) {
+    case "success":
+    case "partial":
+      return true;
+    case "running":
+    case "error":
+      return false;
+    default:
+      status satisfies never;
+      return false;
+  }
 }
 
 export function getSafeRolloutSnapshotAnalysis(

--- a/packages/shared/src/validators/contextual-bandit.ts
+++ b/packages/shared/src/validators/contextual-bandit.ts
@@ -558,7 +558,7 @@ export const getContextualBanditResultsValidator = {
       latest: z
         .object({
           id: z.string(),
-          status: z.enum(["running", "success", "error"]),
+          status: z.enum(["running", "success", "partial-success", "error"]),
           error: z.string(),
           queries: z.array(z.unknown()),
           runStarted: z.string().nullable(),

--- a/packages/shared/src/validators/reports.ts
+++ b/packages/shared/src/validators/reports.ts
@@ -127,7 +127,7 @@ export const apiReportValidator = namedSchema(
       .describe("Snapshot ID (experiment-snapshot type only)")
       .optional(),
     snapshotStatus: z
-      .enum(["running", "success", "error"])
+      .enum(["running", "success", "partial-success", "error"])
       .describe("Status of the latest snapshot (poll this after refresh)")
       .optional(),
     snapshotError: z

--- a/packages/shared/src/validators/safe-rollout-snapshot.ts
+++ b/packages/shared/src/validators/safe-rollout-snapshot.ts
@@ -212,7 +212,7 @@ export type SafeRolloutSnapshotAnalysisSettings = z.infer<
 const safeRolloutSnapshotAnalysisObject = z.object({
   settings: safeRolloutSnapshotAnalysisSettingsValidator,
   dateCreated: z.date(),
-  status: z.enum(["running", "success", "error"]),
+  status: z.enum(["running", "success", "partial", "error"]),
   error: z.string().optional(),
   results: z.array(safeRolloutReportResultDimensionObject),
 });
@@ -232,7 +232,7 @@ export const safeRolloutSnapshotInterface = z
     runStarted: z.date(),
     dimension: z.string().optional(),
     error: z.string().optional(),
-    status: z.enum(["running", "success", "error"]),
+    status: z.enum(["running", "success", "partial-success", "error"]),
     settings: safeRolloutSnapshotSettings,
     triggeredBy: z.enum(["manual", "schedule"]),
     queries: z.array(queryPointerValidator),

--- a/packages/shared/test/util/snapshot-analysis.test.ts
+++ b/packages/shared/test/util/snapshot-analysis.test.ts
@@ -1,4 +1,9 @@
-import { findAnalysisComputeFailure, isAnalysisAllowed } from "../../src/util";
+import {
+  analysisStatusFromResults,
+  findAnalysisComputeFailure,
+  isAnalysisAllowed,
+  snapshotStatusFromAnalyses,
+} from "../../src/util";
 import type {
   ExperimentSnapshotAnalysis,
   ExperimentSnapshotAnalysisSettings,
@@ -44,11 +49,15 @@ describe("isAnalysisAllowed", () => {
 type AnalysisMetrics =
   ExperimentSnapshotAnalysis["results"][number]["variations"][number]["metrics"];
 
-function makeAnalysis(metrics: AnalysisMetrics): ExperimentSnapshotAnalysis {
+function makeAnalysis(
+  metrics: AnalysisMetrics,
+  status: ExperimentSnapshotAnalysis["status"] = "success",
+  otherVariationMetrics: AnalysisMetrics[] = [],
+): ExperimentSnapshotAnalysis {
   return {
     analysisKey: "analysis_1",
     dateCreated: new Date("2026-08-25T00:00:00Z"),
-    status: "success",
+    status,
     settings: {
       dimensions: [],
       statsEngine: "bayesian",
@@ -56,7 +65,16 @@ function makeAnalysis(metrics: AnalysisMetrics): ExperimentSnapshotAnalysis {
       numGoalMetrics: 1,
       numGuardrailMetrics: 0,
     },
-    results: [{ name: "All", srm: 1, variations: [{ users: 0, metrics }] }],
+    results: [
+      {
+        name: "All",
+        srm: 1,
+        variations: [metrics, ...otherVariationMetrics].map((metrics) => ({
+          users: 0,
+          metrics,
+        })),
+      },
+    ],
   };
 }
 
@@ -93,5 +111,70 @@ describe("findAnalysisComputeFailure", () => {
 
   it("accepts a missing analysis", () => {
     expect(findAnalysisComputeFailure(null)).toBeNull();
+  });
+});
+
+describe("analysisStatusFromResults", () => {
+  it("is partial when a metric failed to compute", () => {
+    const analysis = makeAnalysis({
+      failed: {
+        value: 0,
+        cr: 0,
+        users: 0,
+        computeFailed: true,
+        errorMessage: "analysis failed",
+      },
+      healthy: { value: 1, cr: 0.1, users: 10 },
+    });
+
+    expect(analysisStatusFromResults(analysis.results)).toBe("partial");
+  });
+
+  it("is partial when only a later variation carries the failure", () => {
+    const analysis = makeAnalysis(
+      { failed: { value: 1, cr: 0.1, users: 10 } },
+      "success",
+      [{ failed: { value: 0, cr: 0, users: 0, computeFailed: true } }],
+    );
+
+    expect(analysisStatusFromResults(analysis.results)).toBe("partial");
+  });
+
+  it("is success when a metric has a message but did not fail", () => {
+    const analysis = makeAnalysis({
+      healthy: { value: 1, cr: 0.1, users: 10, errorMessage: "no units" },
+    });
+
+    expect(analysisStatusFromResults(analysis.results)).toBe("success");
+  });
+
+  it("is success for empty results", () => {
+    expect(analysisStatusFromResults([])).toBe("success");
+  });
+});
+
+describe("snapshotStatusFromAnalyses", () => {
+  it("returns partial-success when any analysis is partial", () => {
+    expect(
+      snapshotStatusFromAnalyses([
+        { status: "success" },
+        { status: "partial" },
+      ]),
+    ).toBe("partial-success");
+  });
+
+  it("returns success when all analyses succeeded", () => {
+    expect(
+      snapshotStatusFromAnalyses([
+        { status: "success" },
+        { status: "success" },
+      ]),
+    ).toBe("success");
+  });
+
+  it("returns partial-success when a whole analysis errored", () => {
+    expect(
+      snapshotStatusFromAnalyses([{ status: "success" }, { status: "error" }]),
+    ).toBe("partial-success");
   });
 });

--- a/packages/shared/types/experiment-snapshot.d.ts
+++ b/packages/shared/types/experiment-snapshot.d.ts
@@ -33,6 +33,17 @@ import {
   LookbackOverride,
 } from "./experiment";
 
+export type ExperimentSnapshotStatus =
+  | "running"
+  | "success"
+  | "partial-success"
+  | "error";
+export type ExperimentSnapshotAnalysisStatus =
+  | "running"
+  | "success"
+  | "partial"
+  | "error";
+
 export interface SnapshotMetric {
   value: number;
   cr: number;
@@ -161,7 +172,7 @@ export interface ExperimentSnapshotAnalysis {
   // Determines which analysis this is
   settings: ExperimentSnapshotAnalysisSettings;
   dateCreated: Date;
-  status: "running" | "success" | "error";
+  status: ExperimentSnapshotAnalysisStatus;
   error?: string;
   results: ExperimentReportResultDimension[];
 }
@@ -233,7 +244,7 @@ export interface ExperimentSnapshotInterface {
   sourceSnapshotId?: string;
   sourceSnapshotDateCreated?: Date;
   runStarted: Date | null;
-  status: "running" | "success" | "error";
+  status: ExperimentSnapshotStatus;
   settings: ExperimentSnapshotSettings;
   type?: SnapshotType;
   triggeredBy?: SnapshotTriggeredBy;


### PR DESCRIPTION
### Features and Changes

Now that we don't throw errors in case a single metric fails to be analyzed, we need to pass this state up (on main, we currently see the partial success and still consider the snapshot a failure, to keep the previous behavior, which is now being modified by this PR).

So a analysis and a snapshot now can have the status of `partial` and `partial-success` respectively.

### Testing

- Unit tests
