### PR TITLE
fix(ci): queue builds sharing the Depot project

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -10,6 +10,11 @@ on:
 jobs:
   # Build and publish the commit to docker
   docker:
+    # Shared with previews and other builds using the same Depot project.
+    concurrency:
+      group: depot-vmp2ssvj9r
+      queue: max
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'growthbook/growthbook' }}
     permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,11 @@ concurrency:
 jobs:
   # Build and publish the commit to docker
   docker:
+    # Shared with previews and other builds using the same Depot project.
+    concurrency:
+      group: depot-vmp2ssvj9r
+      queue: max
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'growthbook/growthbook' }}
     permissions:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,6 +12,11 @@ on:
       - ".dockerignore"
     types: [opened, reopened, closed, synchronize]
 
+# Cancel outdated revisions of the same PR, including runs waiting for Depot.
+concurrency:
+  group: pr-${{ github.event.number }}
+  cancel-in-progress: true
+
 jobs:
   preview:
     if: >-
@@ -23,9 +28,11 @@ jobs:
       id-token: write
     outputs:
       url: ${{ steps.deploy.outputs.url }}
+    # Shared with production and branch builds using the same Depot project.
     concurrency:
-      group: pr-${{ github.event.number }}
-      cancel-in-progress: true
+      group: depot-vmp2ssvj9r
+      queue: max
+      cancel-in-progress: false
     environment:
       name: preview
       url: ${{ steps.deploy.outputs.url }}


### PR DESCRIPTION
### Features and Changes

Rebasing a stack starts multiple preview builds against the same Depot project. Eight previews failed together with builder keepalive timeouts ([example run](https://github.com/growthbook/growthbook/actions/runs/34435782376)).

Queue the preview, production-image, and branch-image jobs in one shared GitHub concurrency group. `queue: max` retains pending jobs instead of replacing them, and `cancel-in-progress: false` prevents different PRs from canceling each other. Move the existing per-PR cancellation to workflow scope so newer revisions still cancel outdated previews. Keep production's existing workflow ordering.

This deliberately queues the whole preview job to keep the change small: deployment and cleanup also hold a slot, and production image builds can wait behind previews. Production rollout jobs run outside this shared queue. No Depot settings changes are required.

### Testing

- Prettier check and `git diff --check` passed.
- Parsed workflow YAML and asserted that all three jobs building Depot project `vmp2ssvj9r` share the same non-canceling queue; verified existing PR cancellation and production ordering are preserved.
- Live concurrency behavior is not yet tested. After rollout, trigger several previews and confirm one runs while the others queue; update a queued PR and confirm its obsolete run is canceled. This workflow-only PR does not trigger the preview workflow's current path filters.

GitHub's supported queue configuration: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency
