### PR TITLE
Gate Slack sidebar link behind workspace flags

### DIFF
--- a/packages/front-end/components/Layout/sidebarNav.ts
+++ b/packages/front-end/components/Layout/sidebarNav.ts
@@ -318,8 +318,12 @@ export const navlinks: SidebarLinkProps[] = [
         name: "Slack",
         href: "/integrations/slack",
         path: /^integrations\/slack/,
-        filter: ({ permissionsUtils }) =>
-          permissionsUtils.canManageIntegrations(),
+        // Default ON so self-hosted and airgapped installs without a features
+        // payload still see the link; the remote flags only turn it off.
+        filter: ({ permissionsUtils, gb }) =>
+          permissionsUtils.canManageIntegrations() &&
+          ((gb?.getFeatureValue("slack-workspace-ui", true) ?? true) ||
+            (gb?.getFeatureValue("slack-integration", true) ?? true)),
       },
       {
         name: "Import your data",

--- a/packages/shared/types/app-features.ts
+++ b/packages/shared/types/app-features.ts
@@ -34,6 +34,7 @@ export type AppFeatures = {
   "stats-engine-setting": boolean;
   "proxy-cloud": boolean;
   "slack-integration": boolean;
+  "slack-workspace-ui": boolean;
   "new-experiment-modal": boolean;
   "visual-editor-ui": boolean;
   "proxy-cloud-sse": boolean;


### PR DESCRIPTION
### Features and Changes

Recent PR removed a FF gate that was blocking new orgs (after oct 2024) from seeing our defunct slack app. This was done in anticipation of the new slack app, but currently we inappropriately are exposing those orgs to our old, broken slack app. This fixes that and returns control to FF.

### Testing

On local new org, I no longer see Slack in left nav and it responds to overriding settings in devtools as I would expect.