### PR TITLE
feat(webhooks): add API version selection and aggregate significance events

### DIFF
--- a/docs/app/webhooks/event-webhooks.mdx
+++ b/docs/app/webhooks/event-webhooks.mdx
@@ -17,6 +17,14 @@ When logged into GrowthBook as an admin, navigate to **Settings → Webhooks**.
 
 There you can add a webhook endpoint and select which events you want to be notified about.
 
+## API version
+
+JSON webhooks have an API version setting for all subscribed events. New webhooks
+default to `2026-09-11`. Existing webhooks without a saved version use `2024-07-31`;
+updates that omit `apiVersion` keep the saved version.
+Currently, only significance events differ. See the
+[payload and migration details](/app/webhooks/event-webhooks/events).
+
 ## Supported Event Types
 
 See the [full list of events](/app/webhooks/event-webhooks/events).

--- a/docs/app/webhooks/event-webhooks/events.mdx
+++ b/docs/app/webhooks/event-webhooks/events.mdx
@@ -7,6 +7,18 @@ slug: /app/webhooks/event-webhooks/events
 
 import EventWebhookList from '/snippets/partials/event-webhook/_event-webhook-list.mdx';
 
+## API versions
+
+Configure the API version when creating or editing a JSON webhook under
+**Settings → Webhooks**. The setting applies to all events sent to that webhook.
+New webhooks default to `2026-09-11`; existing webhooks keep `2024-07-31` until updated.
+
+In `2026-09-11`, `experiment.info.significance` has a new format containing all
+newly significant metric/variation results for the refresh in `data.object.changes`,
+including slices. Version `2024-07-31` sends one result per event. Both formats are
+listed below. Update your receiver before changing versions; queued deliveries
+and retries keep their saved version.
+
 We currently support the following event types:
 
 <EventWebhookList />

--- a/docs/snippets/partials/event-webhook/_event-webhook-list.mdx
+++ b/docs/snippets/partials/event-webhook/_event-webhook-list.mdx
@@ -3096,18 +3096,68 @@ Triggered when a warning condition is detected on an experiment
 
 Triggered when a goal or guardrail metric reaches significance in an experiment (e.g. either above 95% or below 5% chance to win). Be careful using this without Sequential Testing as it can lead to peeking problems.
 
+#### API version 2026-09-11
+
 <Accordion title="Payload">
 
 ```typescript
 {
     event: "experiment.info.significance";
     object: "experiment";
-    api_version: string;
+    api_version: "2026-09-11";
     created: number;
     data: {
         object: {
             experimentName: string;
             experimentId: string;
+            changes: {
+                variationId: string;
+                variationName: string;
+                metricName: string;
+                metricId: string;
+                statsEngine: string;
+                criticalValue: number;
+                winning: boolean;
+            }[];
+        };
+    };
+    user: {
+        type: "dashboard";
+        id: string;
+        email: string;
+        name: string;
+    } | {
+        type: "api_key";
+        apiKey: string;
+        id?: string | undefined;
+        name?: string | undefined;
+        email?: string | undefined;
+    } | {
+        type: "system";
+        subtype?: string | undefined;
+        id?: string | undefined;
+    } | null;
+    tags: string[];
+    /** The environments affected by the change described by this event. For live-state events (e.g. `feature.updated`) these are the environments whose effective configuration actually changed; for draft lifecycle events (`*.revision.*`) they are the environments the proposed changes would affect. Webhook environment filters match against this field. An empty array means the event has no environment-scoped impact (it will only be delivered to subscriptions without an environment filter). */
+    environments: string[];
+    containsSecrets: boolean;
+}
+```
+
+</Accordion>
+
+#### API version 2024-07-31
+
+<Accordion title="Payload">
+
+```typescript
+{
+    event: "experiment.info.significance";
+    object: "experiment";
+    api_version: "2024-07-31";
+    created: number;
+    data: {
+        object: {
             variationId: string;
             variationName: string;
             metricName: string;
@@ -3115,6 +3165,8 @@ Triggered when a goal or guardrail metric reaches significance in an experiment 
             statsEngine: string;
             criticalValue: number;
             winning: boolean;
+            experimentName: string;
+            experimentId: string;
         };
     };
     user: {

--- a/packages/back-end/src/events/handlers/slack/slack-event-handler-utils.ts
+++ b/packages/back-end/src/events/handlers/slack/slack-event-handler-utils.ts
@@ -12,6 +12,7 @@ import { SlackIntegrationInterface } from "shared/types/slack-integration";
 import {
   ExperimentWarningNotificationPayload,
   ExperimentInfoSignificancePayload,
+  LegacyExperimentInfoSignificancePayload,
   ExperimentInfoScheduledStatusUpdatePayload,
   ExperimentDecisionNotificationPayload,
   SafeRolloutDecisionNotificationPayload,
@@ -1669,7 +1670,42 @@ const buildSlackMessageForExperimentDeletedEvent = async (
   };
 };
 
-const buildSlackMessageForExperimentInfoSignificanceEvent = ({
+const buildSlackMessageForExperimentInfoSignificanceEvent = (
+  data:
+    | ExperimentInfoSignificancePayload
+    | LegacyExperimentInfoSignificancePayload,
+): SlackMessage => {
+  if (!("changes" in data)) {
+    return buildSlackMessageForLegacyExperimentInfoSignificanceEvent(data);
+  }
+
+  const winning = data.changes.filter((change) => change.winning).length;
+  const count = data.changes.length;
+  const text = (experimentName: string) =>
+    `In experiment ${experimentName}, ${count} metric/variation ${
+      count === 1 ? "result" : "results"
+    } newly reached significance. ${winning} winning, ${count - winning} losing.`;
+
+  return {
+    text: `${text(data.experimentName)} View results: ${APP_ORIGIN}/experiment/${data.experimentId}`,
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: text(
+            getExperimentUrlAndNameFormatted(
+              data.experimentId,
+              data.experimentName,
+            ),
+          ),
+        },
+      },
+    ],
+  };
+};
+
+const buildSlackMessageForLegacyExperimentInfoSignificanceEvent = ({
   metricName,
   experimentName,
   experimentId,
@@ -1677,7 +1713,7 @@ const buildSlackMessageForExperimentInfoSignificanceEvent = ({
   statsEngine,
   criticalValue,
   winning,
-}: ExperimentInfoSignificancePayload): SlackMessage => {
+}: LegacyExperimentInfoSignificancePayload): SlackMessage => {
   const percentFormatter = (v: number) => {
     if (v > 0.99) {
       return ">99%";

--- a/packages/back-end/src/events/handlers/webhooks/EventWebHookNotifier.ts
+++ b/packages/back-end/src/events/handlers/webhooks/EventWebHookNotifier.ts
@@ -1,4 +1,5 @@
 import { Agenda, Job, JobAttributesData } from "agenda";
+import { EventWebHookApiVersion } from "shared/validators";
 import {
   EventWebHookInterface,
   EventWebHookMethod,
@@ -33,6 +34,7 @@ import {
   EventWebHookSuccessResult,
   getEventWebHookSignatureForPayload,
 } from "./event-webhooks-utils";
+import { serializeEvent } from "./serializeEvent";
 
 let jobDefined = false;
 
@@ -43,6 +45,12 @@ interface Notifier {
 type EventWebHookNotificationHandlerOptions = {
   eventId: string;
   eventWebHookId: string;
+  // Jobs queued before API versioning have no saved delivery settings.
+  delivery?: {
+    payloadType: EventWebHookInterface["payloadType"];
+    apiVersion: EventWebHookApiVersion;
+    changeIndex: number;
+  };
 };
 
 type EventWebHookJobData = JobAttributesData &
@@ -72,10 +80,14 @@ export class EventWebHookNotifier implements Notifier {
       ...this.options,
       retryCount: 0,
     });
-    job.unique({
-      "data.eventId": this.options.eventId,
-      "data.eventWebHookId": this.options.eventWebHookId,
-    });
+    job.unique(
+      {
+        "data.eventId": this.options.eventId,
+        "data.eventWebHookId": this.options.eventWebHookId,
+        "data.delivery.changeIndex": this.options.delivery?.changeIndex,
+      },
+      { insertOnly: true },
+    );
     job.schedule(new Date());
     await job.save();
   }
@@ -124,17 +136,23 @@ export class EventWebHookNotifier implements Notifier {
       );
     }
 
+    const delivery = job.attrs.data.delivery;
+    const payloadType =
+      delivery?.payloadType ?? eventWebHook.payloadType ?? "raw";
     const payload = await (async () => {
       let invalidPayloadType: never;
-
-      // There might be very old webhook definitions who don't have
-      // a payloadType at all. Assume "raw" in this case.
-      const payloadType = eventWebHook.payloadType || "raw";
 
       switch (payloadType) {
         case "json": {
           if (!event.version) throw new Error("Internal error");
-          return event.data;
+          // Pre-upgrade jobs retain their original payload.
+          return delivery
+            ? serializeEvent(
+                event.data,
+                delivery.apiVersion,
+                delivery.changeIndex,
+              )
+            : event.data;
         }
 
         case "raw": {
@@ -179,7 +197,7 @@ export class EventWebHookNotifier implements Notifier {
     const context = getContextForAgendaJobByOrgObject(organization);
 
     if (
-      (eventWebHook.payloadType || "raw") === "slack" &&
+      payloadType === "slack" &&
       isSlackWorkspacePlaceholderUrl(eventWebHook.url)
     ) {
       const teamId = eventWebHook.slack?.teamId;

--- a/packages/back-end/src/events/handlers/webhooks/EventWebHookNotifier.ts
+++ b/packages/back-end/src/events/handlers/webhooks/EventWebHookNotifier.ts
@@ -34,7 +34,7 @@ import {
   EventWebHookSuccessResult,
   getEventWebHookSignatureForPayload,
 } from "./event-webhooks-utils";
-import { serializeEvent } from "./serializeEvent";
+import { getJsonWebhookPayload } from "./getJsonWebhookPayload";
 
 let jobDefined = false;
 
@@ -147,7 +147,7 @@ export class EventWebHookNotifier implements Notifier {
           if (!event.version) throw new Error("Internal error");
           // Pre-upgrade jobs retain their original payload.
           return delivery
-            ? serializeEvent(
+            ? getJsonWebhookPayload(
                 event.data,
                 delivery.apiVersion,
                 delivery.changeIndex,

--- a/packages/back-end/src/events/handlers/webhooks/EventWebHookNotifier.ts
+++ b/packages/back-end/src/events/handlers/webhooks/EventWebHookNotifier.ts
@@ -100,9 +100,15 @@ export class EventWebHookNotifier implements Notifier {
   private static async handleAgendaJob(
     job: Job<EventWebHookJobData>,
   ): Promise<void> {
-    const { eventId, eventWebHookId } = job.attrs.data;
+    const { eventId, eventWebHookId, delivery } = job.attrs.data;
 
-    const event = await getEvent(eventId);
+    // Legacy JSON jobs need only one change, returned at index 0 by the projection.
+    const event = await getEvent(
+      eventId,
+      delivery?.payloadType === "json" && delivery.apiVersion === "2024-07-31"
+        ? delivery.changeIndex
+        : null,
+    );
     if (!event) {
       // We should never get here.
       throw new Error(
@@ -136,7 +142,6 @@ export class EventWebHookNotifier implements Notifier {
       );
     }
 
-    const delivery = job.attrs.data.delivery;
     const payloadType =
       delivery?.payloadType ?? eventWebHook.payloadType ?? "raw";
     const payload = await (async () => {
@@ -147,11 +152,7 @@ export class EventWebHookNotifier implements Notifier {
           if (!event.version) throw new Error("Internal error");
           // Pre-upgrade jobs retain their original payload.
           return delivery
-            ? getJsonWebhookPayload(
-                event.data,
-                delivery.apiVersion,
-                delivery.changeIndex,
-              )
+            ? getJsonWebhookPayload(event.data, delivery.apiVersion)
             : event.data;
         }
 

--- a/packages/back-end/src/events/handlers/webhooks/getJsonWebhookPayload.ts
+++ b/packages/back-end/src/events/handlers/webhooks/getJsonWebhookPayload.ts
@@ -2,7 +2,7 @@ import { EventWebHookApiVersion } from "shared/validators";
 import { NotificationEvent } from "shared/types/events/base-types";
 
 // Adapt the stored event to the receiver's API version and selected result.
-export function serializeEvent(
+export function getJsonWebhookPayload(
   event: NotificationEvent,
   apiVersion: EventWebHookApiVersion,
   changeIndex = 0,

--- a/packages/back-end/src/events/handlers/webhooks/serializeEvent.ts
+++ b/packages/back-end/src/events/handlers/webhooks/serializeEvent.ts
@@ -1,0 +1,28 @@
+import { EventWebHookApiVersion } from "shared/validators";
+import { NotificationEvent } from "shared/types/events/base-types";
+
+// Adapt the stored event to the receiver's API version and selected result.
+export function serializeEvent(
+  event: NotificationEvent,
+  apiVersion: EventWebHookApiVersion,
+  changeIndex = 0,
+): Record<string, unknown> {
+  const payload = { ...event, api_version: apiVersion };
+  if (event.event !== "experiment.info.significance") return payload;
+
+  const data = event.data.object;
+  // Events created before aggregation keep their original payload and version.
+  if (!("changes" in data)) return event;
+  if (apiVersion === "2026-09-11") return payload;
+
+  return {
+    ...payload,
+    data: {
+      object: {
+        experimentId: data.experimentId,
+        experimentName: data.experimentName,
+        ...data.changes[changeIndex],
+      },
+    },
+  };
+}

--- a/packages/back-end/src/events/handlers/webhooks/webHooksEventHandler.ts
+++ b/packages/back-end/src/events/handlers/webhooks/webHooksEventHandler.ts
@@ -13,16 +13,17 @@ import { EventWebHookNotifier } from "./EventWebHookNotifier";
  * Common handler that looks up the web hooks and makes a post request with the event.
  */
 export const webHooksEventHandler: NotificationEventHandler = async (event) => {
-  const { tags, projects } = getFilterDataForNotificationEvent(event.data) || {
+  const { data: payload, version } = event;
+  const { tags, projects } = getFilterDataForNotificationEvent(payload) || {
     tags: [],
     projects: [],
   };
 
   const eventWebHooks = await (async () => {
-    if (event.data.event === "webhook.test") {
-      const webhookId = event.version
-        ? event.data.data.object.webhookId
-        : event.data.data.webhookId;
+    if (payload.event === "webhook.test") {
+      const webhookId = version
+        ? payload.data.object.webhookId
+        : payload.data.webhookId;
 
       const webhook = await getEventWebHookById(
         webhookId,
@@ -36,22 +37,38 @@ export const webHooksEventHandler: NotificationEventHandler = async (event) => {
       return (
         (await getAllEventWebHooksForEvent({
           organizationId: event.organizationId,
-          eventName: event.data.event,
+          eventName: payload.event,
           enabled: true,
           tags,
           projects,
         })) || []
       ).filter(({ environments = [] }) =>
-        filterEventForEnvironments({ event: event.data, environments }),
+        filterEventForEnvironments({ event: payload, environments }),
       );
     }
   })();
 
   eventWebHooks.forEach((eventWebHook) => {
-    const notifier = new EventWebHookNotifier({
-      eventId: event.id,
-      eventWebHookId: eventWebHook.id,
-    });
-    notifier.enqueue();
+    const apiVersion = eventWebHook.apiVersion ?? "2024-07-31";
+    const count =
+      eventWebHook.payloadType === "json" &&
+      apiVersion === "2024-07-31" &&
+      version &&
+      payload.event === "experiment.info.significance" &&
+      "changes" in payload.data.object
+        ? payload.data.object.changes.length
+        : 1;
+    for (let changeIndex = 0; changeIndex < count; changeIndex++) {
+      const notifier = new EventWebHookNotifier({
+        eventId: event.id,
+        eventWebHookId: eventWebHook.id,
+        delivery: {
+          payloadType: eventWebHook.payloadType || "raw",
+          apiVersion,
+          changeIndex,
+        },
+      });
+      notifier.enqueue();
+    }
   });
 };

--- a/packages/back-end/src/models/EventModel.ts
+++ b/packages/back-end/src/models/EventModel.ts
@@ -24,7 +24,7 @@ import { logger } from "back-end/src/util/logger";
 import { ReqContext } from "back-end/types/request";
 import { EventNotifier } from "back-end/src/events/notifiers/EventNotifier";
 
-const API_VERSION = "2024-07-31" as const;
+const API_VERSION = "2026-09-11" as const;
 const MODEL_VERSION = 1 as const;
 
 const eventSchema = new mongoose.Schema({

--- a/packages/back-end/src/models/EventModel.ts
+++ b/packages/back-end/src/models/EventModel.ts
@@ -268,8 +268,16 @@ export const createEvent = async <
  */
 export const getEvent = async (
   eventId: string,
+  significanceChangeIndex: number | null = null,
 ): Promise<EventInterface | null> => {
-  const doc = await EventModel.findOne({ id: eventId });
+  const doc = await EventModel.findOne(
+    { id: eventId },
+    significanceChangeIndex === null
+      ? null
+      : {
+          "data.data.object.changes": { $slice: [significanceChangeIndex, 1] },
+        },
+  );
   return !doc ? null : (toInterface(doc) as EventInterface);
 };
 

--- a/packages/back-end/src/models/EventWebhookModel.ts
+++ b/packages/back-end/src/models/EventWebhookModel.ts
@@ -8,6 +8,7 @@ import { NotificationEventName } from "shared/types/events/base-types";
 import {
   zodNotificationEventNamesEnum,
   eventWebHookPayloadTypes,
+  eventWebHookApiVersion,
   EventWebHookPayloadType,
   eventWebHookMethods,
   EventWebHookMethod,
@@ -45,6 +46,10 @@ const eventWebHookSchema = new mongoose.Schema({
     channelName: String,
     channelId: String,
     configurationUrl: String,
+  },
+  apiVersion: {
+    type: String,
+    enum: eventWebHookApiVersion.options,
   },
   method: {
     type: String,
@@ -216,6 +221,7 @@ const toInterface = (doc: EventWebHookDocument): EventWebHookInterface => {
   return {
     ...defaults,
     ...payload,
+    apiVersion: payload.apiVersion ?? "2024-07-31",
   };
 };
 
@@ -235,6 +241,7 @@ type CreateEventWebHookOptions = {
   tags: string[];
   environments: string[];
   payloadType: EventWebHookPayloadType;
+  apiVersion?: EventWebHookInterface["apiVersion"];
   method: EventWebHookMethod;
   headers: Record<string, string>;
   slack?: EventWebHookInterface["slack"];
@@ -256,6 +263,7 @@ export const createEventWebHook = async ({
   tags,
   environments,
   payloadType,
+  apiVersion = "2026-09-11",
   method,
   headers,
   slack,
@@ -277,6 +285,7 @@ export const createEventWebHook = async ({
     tags,
     environments,
     payloadType,
+    apiVersion,
     method,
     headers,
     slack,
@@ -352,6 +361,7 @@ export type UpdateEventWebHookAttributes = {
   environments?: string[];
   projects?: string[];
   payloadType?: EventWebHookPayloadType;
+  apiVersion?: EventWebHookInterface["apiVersion"];
   method?: EventWebHookMethod;
   headers?: Record<string, string>;
   slack?: EventWebHookInterface["slack"];

--- a/packages/back-end/src/routers/event-webhooks/event-webhooks.controller.ts
+++ b/packages/back-end/src/routers/event-webhooks/event-webhooks.controller.ts
@@ -101,6 +101,7 @@ type PostEventWebHooksRequest = AuthRequest & {
     environments: string[];
     projects: string[];
     payloadType: EventWebHookPayloadType;
+    apiVersion?: EventWebHookInterface["apiVersion"];
     method: EventWebHookMethod;
     headers: Record<string, string>;
   };
@@ -128,6 +129,7 @@ export const createEventWebHook = async (
     projects = [],
     environments = [],
     payloadType,
+    apiVersion,
     method = "POST",
     headers = {},
   } = req.body;
@@ -142,6 +144,7 @@ export const createEventWebHook = async (
     environments,
     tags,
     payloadType,
+    apiVersion,
     method,
     headers,
   });
@@ -221,7 +224,7 @@ export const deleteEventWebHook = async (
 // region PUT /event-webhooks/:eventWebHookId
 
 type UpdateEventWebHookRequest = AuthRequest<
-  Required<UpdateEventWebHookAttributes>,
+  UpdateEventWebHookAttributes,
   { eventWebHookId: string }
 >;
 

--- a/packages/back-end/src/routers/event-webhooks/event-webhooks.router.ts
+++ b/packages/back-end/src/routers/event-webhooks/event-webhooks.router.ts
@@ -4,6 +4,7 @@ import {
   zodNotificationEventNamesEnum,
   eventWebHookMethods,
   eventWebHookPayloadTypes,
+  eventWebHookApiVersion,
   isEventWebhookWildcard,
 } from "shared/validators";
 import { wrapController } from "back-end/src/routers/wrapController";
@@ -46,6 +47,7 @@ router.post(
         tags: z.array(z.string()),
         environments: z.array(z.string()),
         payloadType: z.enum(eventWebHookPayloadTypes),
+        apiVersion: eventWebHookApiVersion.optional(),
         method: z.enum(eventWebHookMethods),
         headers: z.object({}).catchall(z.string()),
       })
@@ -124,6 +126,7 @@ router.put(
         tags: z.array(z.string()),
         environments: z.array(z.string()),
         payloadType: z.enum(eventWebHookPayloadTypes),
+        apiVersion: eventWebHookApiVersion.optional(),
         method: z.enum(eventWebHookMethods),
         headers: z.object({}).catchall(z.string()),
       })

--- a/packages/back-end/src/services/experimentNotifications.ts
+++ b/packages/back-end/src/services/experimentNotifications.ts
@@ -14,8 +14,10 @@ import {
   getExperimentResultStatus,
   getHealthSettings,
 } from "shared/enterprise";
-import { ExperimentAnalysisSummary } from "shared/validators";
-import { StatsEngine } from "shared/types/stats";
+import {
+  ExperimentAnalysisSummary,
+  ExperimentSignificanceChange,
+} from "shared/validators";
 import {
   ExperimentHealthSettings,
   ExperimentInterface,
@@ -378,18 +380,6 @@ export const notifyNoData = async ({
   return triggered && !experiment.pastNotifications?.includes("no-data");
 };
 
-type ExperimentSignificanceChange = {
-  experimentId: string;
-  experimentName: string;
-  variationId: string;
-  variationName: string;
-  metricId: string;
-  metricName: string;
-  statsEngine: StatsEngine;
-  criticalValue: number;
-  winning: boolean;
-};
-
 const sendSignificanceEmail = async (
   context: Context,
   experiment: ExperimentInterface,
@@ -564,8 +554,6 @@ export const computeExperimentChanges = async ({
       )?.[i] || { id: i + "", name: "" };
 
       experimentChanges.push({
-        experimentId: experiment.id,
-        experimentName: experiment.name,
         variationId,
         variationName,
         metricId: m,
@@ -608,18 +596,18 @@ export const notifySignificance = async ({
     await sendSignificanceEmail(context, experiment, experimentChanges);
   }
 
-  await Promise.all(
-    experimentChanges.map((change) =>
-      dispatchEvent({
-        context,
-        experiment,
-        event: "info.significance",
-        data: {
-          object: change,
-        },
-      }),
-    ),
-  );
+  await dispatchEvent({
+    context,
+    experiment,
+    event: "info.significance",
+    data: {
+      object: {
+        experimentId: experiment.id,
+        experimentName: experiment.name,
+        changes: experimentChanges,
+      },
+    },
+  });
 };
 
 export const notifyDecision = async ({

--- a/packages/back-end/test/events/getJsonWebhookPayload.test.ts
+++ b/packages/back-end/test/events/getJsonWebhookPayload.test.ts
@@ -3,7 +3,7 @@ import {
   eventWebHookInterface,
 } from "shared/validators";
 import { NotificationEvent } from "shared/types/events/base-types";
-import { serializeEvent } from "back-end/src/events/handlers/webhooks/serializeEvent";
+import { getJsonWebhookPayload } from "back-end/src/events/handlers/webhooks/getJsonWebhookPayload";
 
 const change = {
   metricId: "fact__revenue?dim:country=US",
@@ -41,9 +41,9 @@ const batch = {
 } satisfies NotificationEvent;
 
 it("keeps a batch intact for the new version and reconstructs complete legacy payloads", () => {
-  expect(serializeEvent(batch, "2026-09-11")).toEqual(batch);
-  expect(serializeEvent(batch, "2024-07-31", 0)).toEqual(scalar);
-  expect(serializeEvent(batch, "2024-07-31", 1)).toEqual({
+  expect(getJsonWebhookPayload(batch, "2026-09-11")).toEqual(batch);
+  expect(getJsonWebhookPayload(batch, "2024-07-31", 0)).toEqual(scalar);
+  expect(getJsonWebhookPayload(batch, "2024-07-31", 1)).toEqual({
     ...scalar,
     data: {
       object: {
@@ -56,8 +56,8 @@ it("keeps a batch intact for the new version and reconstructs complete legacy pa
 });
 
 it("preserves the original payload and version of stored scalar events", () => {
-  expect(serializeEvent(scalar, "2024-07-31")).toEqual(scalar);
-  expect(serializeEvent(scalar, "2026-09-11")).toEqual(scalar);
+  expect(getJsonWebhookPayload(scalar, "2024-07-31")).toEqual(scalar);
+  expect(getJsonWebhookPayload(scalar, "2026-09-11")).toEqual(scalar);
 });
 
 it("sets the selected version on other events without changing their data", () => {
@@ -68,7 +68,7 @@ it("sets the selected version on other events without changing their data", () =
     data: { object: { webhookId: "ewh_1" } },
   } satisfies NotificationEvent;
   for (const apiVersion of eventWebHookApiVersion.options) {
-    expect(serializeEvent(event, apiVersion)).toEqual({
+    expect(getJsonWebhookPayload(event, apiVersion)).toEqual({
       ...event,
       api_version: apiVersion,
     });

--- a/packages/back-end/test/events/serializeEvent.test.ts
+++ b/packages/back-end/test/events/serializeEvent.test.ts
@@ -1,0 +1,85 @@
+import {
+  eventWebHookApiVersion,
+  eventWebHookInterface,
+} from "shared/validators";
+import { NotificationEvent } from "shared/types/events/base-types";
+import { serializeEvent } from "back-end/src/events/handlers/webhooks/serializeEvent";
+
+const change = {
+  metricId: "fact__revenue?dim:country=US",
+  metricName: "Revenue",
+  variationId: "variation_1",
+  variationName: "Treatment",
+  statsEngine: "bayesian",
+  criticalValue: 0.99,
+  winning: true,
+};
+const scalar = {
+  event: "experiment.info.significance",
+  object: "experiment",
+  api_version: "2024-07-31",
+  created: 123,
+  user: { type: "system" },
+  projects: ["project_1"],
+  tags: [],
+  environments: [],
+  containsSecrets: false,
+  data: {
+    object: { experimentId: "exp_1", experimentName: "Checkout", ...change },
+  },
+} satisfies NotificationEvent;
+const batch = {
+  ...scalar,
+  api_version: "2026-09-11",
+  data: {
+    object: {
+      experimentId: "exp_1",
+      experimentName: "Checkout",
+      changes: [change, { ...change, metricId: "fact__other", winning: false }],
+    },
+  },
+} satisfies NotificationEvent;
+
+it("keeps a batch intact for the new version and reconstructs complete legacy payloads", () => {
+  expect(serializeEvent(batch, "2026-09-11")).toEqual(batch);
+  expect(serializeEvent(batch, "2024-07-31", 0)).toEqual(scalar);
+  expect(serializeEvent(batch, "2024-07-31", 1)).toEqual({
+    ...scalar,
+    data: {
+      object: {
+        ...scalar.data.object,
+        metricId: "fact__other",
+        winning: false,
+      },
+    },
+  });
+});
+
+it("preserves the original payload and version of stored scalar events", () => {
+  expect(serializeEvent(scalar, "2024-07-31")).toEqual(scalar);
+  expect(serializeEvent(scalar, "2026-09-11")).toEqual(scalar);
+});
+
+it("sets the selected version on other events without changing their data", () => {
+  const event = {
+    ...scalar,
+    event: "webhook.test",
+    object: "webhook",
+    data: { object: { webhookId: "ewh_1" } },
+  } satisfies NotificationEvent;
+  for (const apiVersion of eventWebHookApiVersion.options) {
+    expect(serializeEvent(event, apiVersion)).toEqual({
+      ...event,
+      api_version: apiVersion,
+    });
+  }
+});
+
+it("accepts supported versions and omission without defaulting updates", () => {
+  const schema = eventWebHookInterface.pick({ apiVersion: true });
+  expect(schema.parse({})).toEqual({});
+  for (const apiVersion of eventWebHookApiVersion.options) {
+    expect(schema.parse({ apiVersion })).toEqual({ apiVersion });
+  }
+  expect(schema.safeParse({ apiVersion: "2099-01-01" }).success).toBe(false);
+});

--- a/packages/back-end/test/models/EventWebhookModel.test.ts
+++ b/packages/back-end/test/models/EventWebhookModel.test.ts
@@ -43,6 +43,7 @@ describe("getAllEventWebHooksForEvent", () => {
           headers: {},
           method: "POST",
           payloadType: "raw",
+          apiVersion: "2024-07-31",
         },
       ]);
     });
@@ -115,6 +116,7 @@ describe("getAllEventWebHooksForEvent", () => {
           headers: {},
           method: "POST",
           payloadType: "raw",
+          apiVersion: "2024-07-31",
         },
         {
           name: "webhook with filter for event project",
@@ -124,6 +126,7 @@ describe("getAllEventWebHooksForEvent", () => {
           headers: {},
           method: "POST",
           payloadType: "raw",
+          apiVersion: "2024-07-31",
         },
       ]);
     });

--- a/packages/back-end/test/services/experimentNotifications/significanceDelivery.test.ts
+++ b/packages/back-end/test/services/experimentNotifications/significanceDelivery.test.ts
@@ -1,0 +1,229 @@
+import { experimentInterface } from "shared/validators";
+import { parseSliceMetricId } from "shared/experiments";
+import { SnapshotMetric } from "shared/types/experiment-snapshot";
+import { setupApp } from "back-end/test/api/api.setup";
+import { snapshotFactory } from "back-end/test/factories/Snapshot.factory";
+import { factMetricFactory } from "back-end/test/factories/FactMetric.factory";
+import { experimentSnapshot } from "back-end/test/snapshots/experiment.snapshot";
+import { ReqContextClass } from "back-end/src/services/context";
+import { notifySignificance } from "back-end/src/services/experimentNotifications";
+import { EventModel, getEvent } from "back-end/src/models/EventModel";
+import { getAgendaInstance } from "back-end/src/services/queueing";
+import { webHooksEventHandler } from "back-end/src/events/handlers/webhooks/webHooksEventHandler";
+import { EventNotifier } from "back-end/src/events/notifiers/EventNotifier";
+import { EventWebHookNotifier } from "back-end/src/events/handlers/webhooks/EventWebHookNotifier";
+import {
+  createEventWebHook,
+  EventWebHookModel,
+  getEventWebHookById,
+} from "back-end/src/models/EventWebhookModel";
+import { getSlackMessageForNotificationEvent } from "back-end/src/events/handlers/slack/slack-event-handler-utils";
+import {
+  isEmailEnabled,
+  sendExperimentChangesEmail,
+} from "back-end/src/services/email";
+
+jest.mock("back-end/src/services/email", () => ({
+  isEmailEnabled: jest.fn(),
+  sendExperimentChangesEmail: jest.fn(),
+}));
+
+function makeResults() {
+  const metrics = 100,
+    slices = 6,
+    treatments = 4;
+  const metricIds = Array.from({ length: metrics }, (v, i) => `fact__${i}`);
+  const allIds = metricIds.flatMap((id) => [
+    id,
+    ...Array.from({ length: slices }, (v, i) => `${id}?dim:country=level${i}`),
+  ]);
+  const variations = Array.from({ length: treatments + 1 }, (v, i) => ({
+    id: `var_${i}`,
+    name: `Variation ${i}`,
+    key: String(i),
+    screenshots: [],
+  }));
+  const experiment = experimentInterface.strip().parse({
+    ...experimentSnapshot,
+    goalMetrics: metricIds,
+    variations,
+    project: "project_1",
+    tags: ["checkout"],
+    decisionFrameworkSettings: {},
+    phases: [
+      {
+        dateStarted: new Date(),
+        name: "Main",
+        reason: "",
+        coverage: 1,
+        condition: "{}",
+        variations: variations.map(({ id }) => ({ id, status: "active" })),
+        variationWeights: variations.map(() => 1 / variations.length),
+      },
+    ],
+  });
+  const snapshot = snapshotFactory.build({
+    experiment: experiment.id,
+    organization: experiment.organization,
+    type: "standard",
+    triggeredBy: "schedule",
+    analyses: [
+      {
+        analysisKey: "analysis_main",
+        dateCreated: new Date(),
+        status: "success",
+        settings: {
+          dimensions: [],
+          statsEngine: "frequentist",
+          differenceType: "relative",
+          numGoalMetrics: metrics,
+          numGuardrailMetrics: 0,
+        },
+        results: [
+          {
+            name: "All",
+            srm: 1,
+            variations: variations.map((variation, i) => ({
+              users: 10000,
+              metrics: Object.fromEntries(
+                allIds.map((id) => {
+                  const value = i === 0 ? 1000 : i <= 2 ? 2000 : 500;
+                  const result: SnapshotMetric = {
+                    users: 10000,
+                    value,
+                    cr: value / 10000,
+                    expected: value / 1000 - 1,
+                    pValue: 0.00001,
+                    ci: i <= 2 ? [0.5, 1.5] : [-0.75, -0.25],
+                  };
+                  return [id, result];
+                }),
+              ),
+            })),
+          },
+        ],
+      },
+    ],
+  });
+  return { experiment, snapshot };
+}
+
+describe("significance delivery", () => {
+  const { isReady } = setupApp();
+  afterEach(() => jest.restoreAllMocks());
+
+  it("aggregates 2,800 results and uses one managed delivery or one legacy job per result", async () => {
+    await isReady;
+    const context = new ReqContextClass({
+      org: {
+        id: experimentSnapshot.organization,
+        name: "Test organization",
+        ownerEmail: "test@example.com",
+        url: "",
+        dateCreated: new Date(),
+        members: [],
+      },
+      auditUser: { type: "system" },
+      role: "admin",
+      teams: [],
+    });
+    jest.spyOn(context.models.metricGroups, "getAll").mockResolvedValue([]);
+    jest
+      .spyOn(context.models.watch, "getExperimentWatchers")
+      .mockResolvedValue([]);
+    jest
+      .spyOn(context.models.factMetrics, "getById")
+      .mockImplementation(async (id) =>
+        factMetricFactory.build({ id, inverse: id === "fact__0" }),
+      );
+    jest.mocked(isEmailEnabled).mockReturnValue(true);
+    const { experiment, snapshot } = makeResults();
+    const perform = jest.spyOn(EventNotifier.prototype, "perform");
+    await notifySignificance({ context, experiment, snapshot });
+    await Promise.all(perform.mock.results.map(({ value }) => value));
+    const documents = await EventModel.find({
+      event: "experiment.info.significance",
+    });
+    expect(documents).toHaveLength(1);
+    const agenda = getAgendaInstance();
+    expect(await agenda.jobs({ name: "eventCreated" })).toHaveLength(1);
+    const event = await getEvent(documents[0].id);
+    if (
+      !event?.version ||
+      event.data.event !== "experiment.info.significance" ||
+      !("changes" in event.data.data.object)
+    )
+      throw new Error("Missing aggregate event");
+    const { changes } = event.data.data.object;
+    expect(changes).toHaveLength(2800);
+    expect(
+      changes
+        .filter((change) => change.metricId === "fact__0")
+        .map(({ winning }) => winning),
+    ).toEqual([false, false, true, true]);
+    expect(
+      changes.filter(
+        (change) => parseSliceMetricId(change.metricId).isSliceMetric,
+      ),
+    ).toHaveLength(2400);
+    expect(sendExperimentChangesEmail).toHaveBeenCalledTimes(1);
+
+    for (const destination of [
+      { name: "legacy", payloadType: "json", apiVersion: "2024-07-31" },
+      { name: "batch", payloadType: "json" },
+      { name: "slack", payloadType: "slack" },
+      { name: "discord", payloadType: "discord" },
+    ] as const) {
+      const webhook = await createEventWebHook({
+        ...destination,
+        organizationId: context.org.id,
+        url: "https://example.test/webhook",
+        enabled: true,
+        events: ["experiment.info.significance"],
+        projects: [],
+        tags: [],
+        environments: [],
+        method: "POST",
+        headers: {},
+      });
+      if (destination.name === "legacy") {
+        expect(webhook.apiVersion).toBe("2024-07-31");
+        await EventWebHookModel.updateOne(
+          { id: webhook.id },
+          { $unset: { apiVersion: 1 } },
+        );
+        expect(
+          (await getEventWebHookById(webhook.id, context.org.id))?.apiVersion,
+        ).toBe("2024-07-31");
+      } else {
+        expect(webhook.apiVersion).toBe("2026-09-11");
+      }
+    }
+    const enqueue = jest.spyOn(EventWebHookNotifier.prototype, "enqueue");
+    await webHooksEventHandler(event, context);
+    await Promise.all(enqueue.mock.results.map(({ value }) => value));
+    const jobs = await agenda.jobs({ name: "eventWebHook" });
+    expect(jobs).toHaveLength(2803);
+    const legacy = jobs.filter(
+      ({ attrs }) =>
+        attrs.data.delivery.payloadType === "json" &&
+        attrs.data.delivery.apiVersion === "2024-07-31",
+    );
+    expect(
+      new Set(legacy.map(({ attrs }) => attrs.data.delivery.changeIndex)).size,
+    ).toBe(2800);
+    for (const payloadType of ["slack", "discord"]) {
+      expect(
+        jobs.filter(
+          ({ attrs }) => attrs.data.delivery.payloadType === payloadType,
+        ),
+      ).toHaveLength(1);
+    }
+    const message = await getSlackMessageForNotificationEvent(
+      event.data,
+      event.id,
+    );
+    expect(message?.text).toContain("2800 metric/variation results");
+    expect(message?.text).toContain("1400 winning, 1400 losing");
+  });
+});

--- a/packages/front-end/components/DocLink.tsx
+++ b/packages/front-end/components/DocLink.tsx
@@ -29,6 +29,7 @@ const docSections = {
   powerCalculator: "/statistics/power",
   api: "/app/api",
   eventWebhooks: "/app/webhooks/event-webhooks",
+  eventWebhookVersions: "/app/webhooks/event-webhooks/events#api-versions",
   sdkWebhooks: "/app/webhooks/sdk-webhooks",
   productAnalytics: "/app/product-analytics",
   "sdkWebhooks#payload-format": "/app/webhooks/sdk-webhooks#payload-format",

--- a/packages/front-end/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal.tsx
@@ -233,12 +233,12 @@ const EventWebHookAddEditSettings = ({
               { value: "2026-09-11", label: "2026-09-11" },
               { value: "2024-07-31", label: "2024-07-31" },
             ]}
+            helpText={
+              <DocLink useRadix={false} docSection="eventWebhookVersions">
+                View API version changes
+              </DocLink>
+            }
           />
-          <Text as="p" size="sm" color="text-low" mt="2">
-            <DocLink docSection="eventWebhookVersions">
-              View API version changes
-            </DocLink>
-          </Text>
         </Box>
       )}
 

--- a/packages/front-end/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal.tsx
@@ -4,7 +4,10 @@ import { useForm, UseFormReturn } from "react-hook-form";
 import clsx from "clsx";
 import { Box, Flex } from "@radix-ui/themes";
 import { PiArrowLeft, PiCaretRight, PiCheckCircleFill } from "react-icons/pi";
-import { isEventWebhookWildcard } from "shared/validators";
+import {
+  eventWebHookApiVersion,
+  isEventWebhookWildcard,
+} from "shared/validators";
 import Text from "@/ui/Text";
 import { useAuth } from "@/services/auth";
 import Modal from "@/components/Modal";
@@ -216,6 +219,28 @@ const EventWebHookAddEditSettings = ({
           handleFormValidation();
         }}
       />
+
+      {selectedPayloadType === "json" && (
+        <Box mt="4">
+          <SelectField
+            label="API version"
+            sort={false}
+            value={form.watch("apiVersion") ?? "2024-07-31"}
+            onChange={(value) =>
+              form.setValue("apiVersion", eventWebHookApiVersion.parse(value))
+            }
+            options={[
+              { value: "2026-09-11", label: "2026-09-11" },
+              { value: "2024-07-31", label: "2024-07-31" },
+            ]}
+          />
+          <Text as="p" size="sm" color="text-low" mt="2">
+            <DocLink docSection="eventWebhookVersions">
+              View API version changes
+            </DocLink>
+          </Text>
+        </Box>
+      )}
 
       <Box mt="4">
         <Field
@@ -482,7 +507,7 @@ export const EventWebHookAddEditModal: FC<EventWebHookAddEditModalProps> = ({
   const form = useForm<EventWebHookEditParams>({
     defaultValues:
       mode.mode === "edit"
-        ? mode.data
+        ? { ...mode.data, apiVersion: mode.data.apiVersion ?? "2024-07-31" }
         : {
             name: "",
             events: [],
@@ -492,6 +517,7 @@ export const EventWebHookAddEditModal: FC<EventWebHookAddEditModalProps> = ({
             projects: [],
             tags: [],
             payloadType: "json",
+            apiVersion: "2026-09-11",
             method: "POST",
             headers: "{}",
           },
@@ -543,6 +569,7 @@ export const EventWebHookAddEditModal: FC<EventWebHookAddEditModalProps> = ({
           : eventWebHookPayloadTypes,
       ),
       tags: z.array(z.string()),
+      apiVersion: eventWebHookApiVersion,
       projects: z.array(z.string()),
       environments: z.array(z.string()),
       method: z.enum(eventWebHookMethods),

--- a/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
@@ -264,6 +264,12 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
         )}
       </Box>
 
+      {payloadType === "json" && (
+        <Text as="p" ml="2" mt="2">
+          API version: {eventWebHook.apiVersion ?? "2024-07-31"}
+        </Text>
+      )}
+
       {["raw", "json"].includes(payloadType) && (
         <Flex align="center" gap="2" ml="2" mt="2">
           <Text weight="semibold">Secret:</Text>
@@ -422,6 +428,7 @@ export const EventWebHookDetailContainer = ({
               "url",
               "enabled",
               "payloadType",
+              "apiVersion",
               "projects",
               "tags",
               "environments",

--- a/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
@@ -265,9 +265,10 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
       </Box>
 
       {payloadType === "json" && (
-        <Text as="p" ml="2" mt="2">
-          API version: {eventWebHook.apiVersion ?? "2024-07-31"}
-        </Text>
+        <Flex align="center" gap="2" ml="2" mt="2">
+          <Text weight="semibold">API version:</Text>
+          <Text>{eventWebHook.apiVersion ?? "2024-07-31"}</Text>
+        </Flex>
       )}
 
       {["raw", "json"].includes(payloadType) && (

--- a/packages/front-end/components/EventWebHooks/utils.tsx
+++ b/packages/front-end/components/EventWebHooks/utils.tsx
@@ -1,5 +1,6 @@
 import {
   NotificationEventNameOrWildcard,
+  EventWebHookApiVersion,
   notificationEventNames as allNotificationEventNames,
   notificationEvents,
 } from "shared/validators";
@@ -41,6 +42,7 @@ export type EventWebHookEditParams = {
   environments: string[];
   projects: string[];
   payloadType: EventWebHookPayloadType;
+  apiVersion?: EventWebHookApiVersion;
   method: EventWebHookMethod;
   headers: string;
 };

--- a/packages/shared/scripts/gen-event-webhook-doc.ts
+++ b/packages/shared/scripts/gen-event-webhook-doc.ts
@@ -5,6 +5,8 @@ import { z } from "zod";
 import {
   notificationEvents,
   notificationEventPayload,
+  experimentInfoSignificance,
+  legacyExperimentInfoSignificance,
 } from "shared/validators";
 
 const basePath = path.resolve(path.dirname(process.argv[1]), "../../../docs");
@@ -39,12 +41,7 @@ const eventTableEntry = ({ name, description }) =>
 
 const quote = "```";
 
-const eventEntry = async ({ name, description, payload }) => `
-### ${name}
-
-${description}
-
-<Accordion title="Payload">
+const payloadEntry = async (payload: z.ZodType) => `<Accordion title="Payload">
 
 ${quote}typescript
 ${await typeScriptSchema(payload)}
@@ -52,6 +49,27 @@ ${quote}
 
 </Accordion>
 `;
+
+const eventEntry = async ({ name, description, payload }) => {
+  const payloads =
+    name === "experiment.info.significance"
+      ? await Promise.all(
+          (
+            [
+              ["2026-09-11", experimentInfoSignificance],
+              ["2024-07-31", legacyExperimentInfoSignificance],
+            ] as const
+          ).map(async ([version, schema]) => {
+            const versionedPayload = payload.extend({
+              api_version: z.literal(version),
+              data: z.object({ object: schema }),
+            });
+            return `#### API version ${version}\n\n${await payloadEntry(versionedPayload)}`;
+          }),
+        )
+      : [await payloadEntry(payload)];
+  return `### ${name}\n\n${description}\n\n${payloads.join("\n")}`;
+};
 
 const content = async () => {
   const eventEntries = await Promise.all(events.map(eventEntry));

--- a/packages/shared/src/validators/event-webhook.ts
+++ b/packages/shared/src/validators/event-webhook.ts
@@ -11,6 +11,9 @@ export const eventWebHookPayloadTypes = [
 
 export type EventWebHookPayloadType = (typeof eventWebHookPayloadTypes)[number];
 
+export const eventWebHookApiVersion = z.enum(["2024-07-31", "2026-09-11"]);
+export type EventWebHookApiVersion = z.infer<typeof eventWebHookApiVersion>;
+
 export const eventWebHookMethods = ["POST", "PUT", "PATCH"] as const;
 
 export type EventWebHookMethod = (typeof eventWebHookMethods)[number];
@@ -72,6 +75,7 @@ export const eventWebHookInterface = z
     tags: z.array(z.string()),
     environments: z.array(z.string()),
     payloadType: z.enum(eventWebHookPayloadTypes),
+    apiVersion: eventWebHookApiVersion.optional(),
     method: z.enum(eventWebHookMethods),
     headers: z.record(z.string(), z.string()),
     slack: slackEventWebHookMetadata.optional(),

--- a/packages/shared/src/validators/events.ts
+++ b/packages/shared/src/validators/events.ts
@@ -45,6 +45,7 @@ import {
 import { experimentWarningNotificationPayload } from "./experiment-warnings";
 import {
   experimentInfoSignificance,
+  legacyExperimentInfoSignificance,
   experimentInfoScheduledStatusUpdate,
 } from "./experiment-info";
 import { experimentDecisionNotificationPayload } from "./experiment-decision";
@@ -299,7 +300,10 @@ export const notificationEvents = {
         "Triggered when a warning condition is detected on an experiment",
     },
     "info.significance": {
-      schema: experimentInfoSignificance,
+      schema: z.union([
+        experimentInfoSignificance,
+        legacyExperimentInfoSignificance,
+      ]),
       description: `Triggered when a goal or guardrail metric reaches significance in an experiment (e.g. either above 95% or below 5% chance to win). Be careful using this without Sequential Testing as it can lead to peeking problems.`,
     },
     "info.scheduled-status-update": {

--- a/packages/shared/src/validators/experiment-info.ts
+++ b/packages/shared/src/validators/experiment-info.ts
@@ -1,9 +1,7 @@
 import { z } from "zod";
 
-export const experimentInfoSignificance = z
+export const experimentSignificanceChange = z
   .object({
-    experimentName: z.string(),
-    experimentId: z.string(),
     variationId: z.string(),
     variationName: z.string(),
     metricName: z.string(),
@@ -13,6 +11,29 @@ export const experimentInfoSignificance = z
     winning: z.boolean(),
   })
   .strict();
+
+export const experimentInfoSignificance = z
+  .object({
+    experimentName: z.string(),
+    experimentId: z.string(),
+    changes: z.array(experimentSignificanceChange).min(1),
+  })
+  .strict();
+
+export const legacyExperimentInfoSignificance = experimentSignificanceChange
+  .extend({
+    experimentName: z.string(),
+    experimentId: z.string(),
+  })
+  .strict();
+
+export type ExperimentSignificanceChange = z.infer<
+  typeof experimentSignificanceChange
+>;
+
+export type LegacyExperimentInfoSignificancePayload = z.infer<
+  typeof legacyExperimentInfoSignificance
+>;
 
 export type ExperimentInfoSignificancePayload = z.infer<
   typeof experimentInfoSignificance


### PR DESCRIPTION
### Features and Changes

- Add an API version setting for JSON webhooks. New webhooks default to `2026-09-11`; existing webhooks keep `2024-07-31`.
- Create one significance event per experiment refresh, with all changed results in `changes`, to reduce event queue volume.
- Automatically send one significance summary to Slack and Discord.
- Preserve one delivery per result for legacy JSON webhooks and document both payload formats.

### Testing

- Webhook and significance tests: 21 passing.
- Shared build, type checks, targeted lint and formatting, and docs generation/checks.
