### PR TITLE
Skip significance dispatch when no event subscribers match

### DIFF
--- a/packages/back-end/src/events/handlers/utils.ts
+++ b/packages/back-end/src/events/handlers/utils.ts
@@ -25,7 +25,7 @@ export const filterEventForEnvironments = ({
   event,
   environments,
 }: {
-  event: NotificationEvent | LegacyNotificationEvent;
+  event: Pick<NotificationEvent | LegacyNotificationEvent, "environments">;
   environments: string[];
 }): boolean => {
   // if the environments are not specified, notify for all environments

--- a/packages/back-end/src/events/hasEventSubscribers.ts
+++ b/packages/back-end/src/events/hasEventSubscribers.ts
@@ -1,0 +1,34 @@
+import { getAllEventWebHooksForEvent } from "back-end/src/models/EventWebhookModel";
+import { getSlackIntegrationsForFilters } from "back-end/src/models/SlackIntegrationModel";
+import { logger } from "back-end/src/util/logger";
+import { filterEventForEnvironments } from "./handlers/utils";
+
+export async function hasEventSubscribers({
+  environments,
+  ...filters
+}: Omit<Parameters<typeof getAllEventWebHooksForEvent>[0], "enabled"> & {
+  environments: string[];
+}): Promise<boolean> {
+  try {
+    const [webhooks, slackIntegrations] = await Promise.all([
+      getAllEventWebHooksForEvent({ ...filters, enabled: true }),
+      getSlackIntegrationsForFilters(filters),
+    ]);
+
+    // A failed legacy Slack lookup returns null. Keep dispatching if uncertain.
+    if (slackIntegrations === null) return true;
+
+    return [...webhooks, ...slackIntegrations].some((subscription) =>
+      filterEventForEnvironments({
+        event: { environments },
+        environments: subscription.environments || [],
+      }),
+    );
+  } catch (error) {
+    logger.error(
+      error,
+      "Could not check event subscriptions; keeping dispatch",
+    );
+    return true;
+  }
+}

--- a/packages/back-end/src/models/EventModel.ts
+++ b/packages/back-end/src/models/EventModel.ts
@@ -112,6 +112,7 @@ export const createEventWithPayload = async <
   payload,
   organizationId,
   objectId,
+  notify = true,
 }: {
   payload: Omit<
     NotificationEventPayload<Resource, Event>,
@@ -119,6 +120,8 @@ export const createEventWithPayload = async <
   >;
   organizationId: string;
   objectId?: string;
+  // Save event history even when webhook and legacy Slack dispatch is skipped.
+  notify?: boolean;
 }) => {
   try {
     const eventId = `event-${randomUUID()}`;
@@ -139,7 +142,7 @@ export const createEventWithPayload = async <
       typeof MODEL_VERSION
     >;
 
-    new EventNotifier(event.id).perform();
+    if (notify) await new EventNotifier(event.id).perform();
   } catch (e) {
     logger.error(e);
   }
@@ -231,6 +234,7 @@ export type CreateEventParams<
   projects: string[];
   tags: string[];
   environments: string[];
+  notify?: boolean;
 };
 
 export const createEvent = async <
@@ -246,6 +250,7 @@ export const createEvent = async <
   projects,
   tags,
   environments,
+  notify = true,
 }: CreateEventParams<Resource, Event>) =>
   createEventWithPayload<Resource, Event>({
     payload: {
@@ -259,6 +264,7 @@ export const createEvent = async <
       user: context.auditUser ?? { type: "system" },
     },
     organizationId: context.org.id,
+    notify,
     ...(objectId ? { objectId } : {}),
   });
 

--- a/packages/back-end/src/services/experimentNotifications.ts
+++ b/packages/back-end/src/services/experimentNotifications.ts
@@ -32,6 +32,7 @@ import { updateExperiment } from "back-end/src/models/ExperimentModel";
 import { logger } from "back-end/src/util/logger";
 import { getLatestSuccessfulSnapshot } from "back-end/src/models/ExperimentSnapshotModel";
 import { getExperimentMetricById } from "back-end/src/services/experiments";
+import { hasEventSubscribers } from "back-end/src/events/hasEventSubscribers";
 import {
   getEnvironmentIdsFromOrg,
   getMetricDefaultsForOrg,
@@ -45,11 +46,13 @@ const dispatchEvent = async <T extends ResourceEvents<"experiment">>({
   experiment,
   event,
   data,
+  notify = true,
 }: {
   context: Context;
   experiment: ExperimentInterface;
   event: T;
   data: CreateEventData<"experiment", T>;
+  notify?: boolean;
 }) => {
   const changedEnvs = includeExperimentInPayload(experiment)
     ? getEnvironmentIdsFromOrg(context.org)
@@ -65,6 +68,7 @@ const dispatchEvent = async <T extends ResourceEvents<"experiment">>({
     environments: changedEnvs,
     tags: experiment.tags || [],
     containsSecrets: false,
+    notify,
   });
 };
 
@@ -609,12 +613,23 @@ export const notifySignificance = async ({
     await sendSignificanceEmail(context, experiment, experimentChanges);
   }
 
+  const notify = await hasEventSubscribers({
+    organizationId: context.org.id,
+    eventName: "experiment.info.significance",
+    projects: experiment.project ? [experiment.project] : [],
+    tags: experiment.tags || [],
+    environments: includeExperimentInPayload(experiment)
+      ? getEnvironmentIdsFromOrg(context.org)
+      : [],
+  });
+
   await Promise.all(
     experimentChanges.map((change) =>
       dispatchEvent({
         context,
         experiment,
         event: "info.significance",
+        notify,
         data: {
           object: change,
         },

--- a/packages/back-end/test/events/hasEventSubscribers.test.ts
+++ b/packages/back-end/test/events/hasEventSubscribers.test.ts
@@ -1,0 +1,147 @@
+import { setupApp } from "back-end/test/api/api.setup";
+import { hasEventSubscribers } from "back-end/src/events/hasEventSubscribers";
+import {
+  createEventWebHook,
+  getAllEventWebHooksForEvent,
+} from "back-end/src/models/EventWebhookModel";
+import {
+  createSlackIntegration,
+  getSlackIntegrationsForFilters,
+} from "back-end/src/models/SlackIntegrationModel";
+
+jest.mock("back-end/src/models/EventWebhookModel", () => ({
+  ...jest.requireActual("back-end/src/models/EventWebhookModel"),
+  getAllEventWebHooksForEvent: jest.fn(
+    jest.requireActual("back-end/src/models/EventWebhookModel")
+      .getAllEventWebHooksForEvent,
+  ),
+}));
+jest.mock("back-end/src/models/SlackIntegrationModel", () => ({
+  ...jest.requireActual("back-end/src/models/SlackIntegrationModel"),
+  getSlackIntegrationsForFilters: jest.fn(
+    jest.requireActual("back-end/src/models/SlackIntegrationModel")
+      .getSlackIntegrationsForFilters,
+  ),
+}));
+
+const { isReady } = setupApp();
+beforeEach(async () => {
+  await isReady;
+});
+
+const filters = {
+  organizationId: "org-subscribers",
+  eventName: "experiment.info.significance",
+  projects: ["checkout"],
+  tags: ["revenue"],
+  environments: ["production"],
+} satisfies Parameters<typeof hasEventSubscribers>[0];
+
+async function webhook(
+  overrides: Partial<Parameters<typeof createEventWebHook>[0]> = {},
+) {
+  await createEventWebHook({
+    organizationId: filters.organizationId,
+    name: "Subscription test",
+    url: "http://localhost/unused",
+    enabled: true,
+    events: ["experiment.info.significance"],
+    projects: [],
+    tags: [],
+    environments: [],
+    payloadType: "json",
+    method: "POST",
+    headers: {},
+    ...overrides,
+  });
+}
+
+async function slack(
+  overrides: Partial<Parameters<typeof createSlackIntegration>[0]> = {},
+) {
+  await createSlackIntegration({
+    organizationId: filters.organizationId,
+    name: "Legacy Slack subscription",
+    description: "",
+    projects: [],
+    environments: [],
+    events: [],
+    tags: [],
+    slackAppId: "test",
+    slackIncomingWebHook: "http://localhost/unused",
+    slackSigningKey: "test",
+    linkedByUserId: "test",
+    ...overrides,
+  });
+}
+
+it("skips dispatch when neither subscription system has a consumer", async () => {
+  expect(await hasEventSubscribers(filters)).toBe(false);
+});
+
+it.each<Partial<Parameters<typeof createEventWebHook>[0]>>([
+  {},
+  { events: ["experiment.*"] },
+  { projects: ["checkout"], tags: ["revenue"], environments: ["production"] },
+  { payloadType: "slack" },
+  { payloadType: "discord" },
+])("keeps matching webhooks: %j", async (overrides) => {
+  await webhook(overrides);
+  expect(await hasEventSubscribers(filters)).toBe(true);
+});
+
+it.each<Partial<Parameters<typeof createEventWebHook>[0]>>([
+  { enabled: false },
+  { events: ["feature.*"] },
+  { organizationId: "another-org" },
+  { projects: ["another-project"] },
+  { tags: ["another-tag"] },
+  { environments: ["staging"] },
+])("ignores non-matching webhooks: %j", async (overrides) => {
+  await webhook(overrides);
+  expect(await hasEventSubscribers(filters)).toBe(false);
+});
+
+it.each<Partial<Parameters<typeof createSlackIntegration>[0]>>([
+  {},
+  { events: ["experiment.info.significance"] },
+  { events: ["experiment.*"] },
+])(
+  "keeps legacy Slack subscriptions, including empty event lists: %j",
+  async (overrides) => {
+    await slack(overrides);
+    expect(await hasEventSubscribers(filters)).toBe(true);
+  },
+);
+
+it("applies legacy Slack routing filters", async () => {
+  await slack({ events: ["feature.*"] });
+  await slack({ organizationId: "another-org" });
+  await slack({ projects: ["another-project"] });
+  await slack({ tags: ["another-tag"] });
+  await slack({ environments: ["staging"] });
+  expect(await hasEventSubscribers(filters)).toBe(false);
+});
+
+it("does not match environment-scoped subscriptions for an unscoped event", async () => {
+  await webhook({ environments: ["production"] });
+  await slack({ environments: ["production"] });
+  expect(await hasEventSubscribers({ ...filters, environments: [] })).toBe(
+    false,
+  );
+});
+
+it("rechecks new subscriptions without caching a negative result", async () => {
+  expect(await hasEventSubscribers(filters)).toBe(false);
+  await webhook();
+  expect(await hasEventSubscribers(filters)).toBe(true);
+});
+
+it("keeps dispatching if either subscription lookup fails", async () => {
+  jest.mocked(getSlackIntegrationsForFilters).mockResolvedValueOnce(null);
+  expect(await hasEventSubscribers(filters)).toBe(true);
+  jest
+    .mocked(getAllEventWebHooksForEvent)
+    .mockRejectedValueOnce(new Error("Injected lookup failure"));
+  expect(await hasEventSubscribers(filters)).toBe(true);
+});

--- a/packages/back-end/test/services/experimentNotifications/significanceDispatch.test.ts
+++ b/packages/back-end/test/services/experimentNotifications/significanceDispatch.test.ts
@@ -1,0 +1,138 @@
+import mongoose from "mongoose";
+import { SnapshotMetric } from "shared/types/experiment-snapshot";
+import { setupApp } from "back-end/test/api/api.setup";
+import { snapshotFactory } from "back-end/test/factories/Snapshot.factory";
+import { createOrganization } from "back-end/src/models/OrganizationModel";
+import { createEventWebHook } from "back-end/src/models/EventWebhookModel";
+import { ExperimentModel } from "back-end/src/models/ExperimentModel";
+import { EventModel } from "back-end/src/models/EventModel";
+import { ReqContextClass } from "back-end/src/services/context";
+import { notifySignificance } from "back-end/src/services/experimentNotifications";
+import { getAgendaInstance } from "back-end/src/services/queueing";
+import { hasEventSubscribers } from "back-end/src/events/hasEventSubscribers";
+import { sendExperimentChangesEmail } from "back-end/src/services/email";
+import { metrics, experiments } from "./experimentSignificance.mocks.json";
+
+jest.mock("back-end/src/events/hasEventSubscribers", () => ({
+  hasEventSubscribers: jest.fn(
+    jest.requireActual("back-end/src/events/hasEventSubscribers")
+      .hasEventSubscribers,
+  ),
+}));
+jest.mock("back-end/src/services/email", () => ({
+  ...jest.requireActual("back-end/src/services/email"),
+  isEmailEnabled: () => true,
+  sendExperimentChangesEmail: jest.fn(),
+}));
+
+const { isReady } = setupApp();
+
+it.each([false, true])(
+  "preserves history and email, and checks subscriptions once per batch: subscribed=%s",
+  async (subscribed) => {
+    await isReady;
+    const queue = getAgendaInstance();
+    await queue._collection.deleteMany({});
+    const org = await createOrganization({
+      email: "significance@example.test",
+      userId: "significance-test",
+      name: "Significance test",
+    });
+    const context = new ReqContextClass({
+      org,
+      role: "admin",
+      auditUser: { type: "system" },
+    });
+    const metric = metrics[0];
+    await mongoose.connection
+      .collection("metrics")
+      .insertOne({ ...metric, organization: org.id });
+    const experiment = await ExperimentModel.create({
+      ...experiments[0],
+      organization: org.id,
+      goalMetrics: [metric.id],
+      guardrails: [],
+    });
+    if (subscribed) {
+      await createEventWebHook({
+        organizationId: org.id,
+        name: "Significance consumer",
+        url: "http://localhost/unused",
+        enabled: true,
+        events: ["experiment.info.*"],
+        projects: [],
+        tags: [],
+        environments: [],
+        payloadType: "json",
+        method: "POST",
+        headers: {},
+      });
+    }
+    const ids = ["US", "CA", "GB"].map(
+      (country) => `${metric.id}?dim:country=${country}`,
+    );
+    const baseline: SnapshotMetric = { users: 10000, value: 8000, cr: 0.8 };
+    const treatment: SnapshotMetric = {
+      users: 10000,
+      value: 6000,
+      cr: 0.6,
+      expected: -0.25,
+      chanceToWin: 0.00001,
+      ci: [-0.3, -0.2],
+    };
+    const snapshot = snapshotFactory.build({
+      experiment: experiment.id,
+      organization: org.id,
+      type: "standard",
+      triggeredBy: "schedule",
+      settings: { goalMetrics: [metric.id] },
+      analyses: [
+        {
+          analysisKey: "default",
+          dateCreated: new Date(),
+          status: "success",
+          settings: {
+            statsEngine: "bayesian",
+            dimensions: [],
+            differenceType: "relative",
+            numGoalMetrics: 1,
+            numGuardrailMetrics: 0,
+          },
+          results: [
+            {
+              name: "",
+              srm: 1,
+              variations: [baseline, treatment].map((stats) => ({
+                users: 10000,
+                metrics: Object.fromEntries(ids.map((id) => [id, stats])),
+              })),
+            },
+          ],
+        },
+      ],
+    });
+
+    await notifySignificance({ context, experiment, snapshot });
+
+    expect(hasEventSubscribers).toHaveBeenCalledTimes(1);
+    expect(sendExperimentChangesEmail).toHaveBeenCalledTimes(1);
+    const history = await EventModel.find({
+      event: "experiment.info.significance",
+    });
+    expect(history).toHaveLength(3);
+    expect(history.map((event) => event.data)).toEqual(
+      expect.arrayContaining(
+        ids.map((metricId) =>
+          expect.objectContaining({
+            data: expect.objectContaining({
+              object: expect.objectContaining({ metricId }),
+            }),
+          }),
+        ),
+      ),
+    );
+    expect(
+      await queue._collection.countDocuments({ name: "eventCreated" }),
+    ).toBe(subscribed ? 3 : 0);
+  },
+);


### PR DESCRIPTION
### Features and Changes

If we don't have anyone listening to the significance event, let's just skip it.