### PR TITLE
Add editable display names for tags

### DIFF
--- a/packages/back-end/src/models/TagModel.ts
+++ b/packages/back-end/src/models/TagModel.ts
@@ -1,6 +1,7 @@
 import mongoose from "mongoose";
 import { TagDBInterface, TagInterface } from "shared/types/tag";
 import { touchDefinitionsVersion } from "back-end/src/models/DefinitionsVersionModel";
+import { BadRequestError } from "back-end/src/util/errors";
 
 const tagSchema = new mongoose.Schema({
   organization: {
@@ -18,6 +19,13 @@ const TagModel = mongoose.model<TagDBInterface>("Tag", tagSchema);
 const MIN_TAG_LENGTH = 2;
 const MAX_TAG_LENGTH = 64;
 
+function getTagLabel(
+  tag: string,
+  settings: TagDBInterface["settings"],
+): string {
+  return settings[tag]?.label ?? tag;
+}
+
 function toTagInterface(doc: TagDocument | null): TagInterface[] {
   if (!doc) return [];
   const json = doc.toJSON<TagDBInterface>();
@@ -28,6 +36,7 @@ function toTagInterface(doc: TagDocument | null): TagInterface[] {
       id: t,
       color: settings[t]?.color || "#029dd1",
       description: settings[t]?.description || "",
+      label: getTagLabel(t, settings),
     };
   });
 }
@@ -66,6 +75,7 @@ export async function addTag(
   tag: string,
   color: string,
   description: string,
+  label?: string,
 ) {
   if (tag.length < MIN_TAG_LENGTH || tag.length > MAX_TAG_LENGTH) {
     throw new Error(
@@ -80,7 +90,27 @@ export async function addTag(
     organization,
   });
   const settings = existing?.settings || {};
-  settings[tag] = { color, description };
+  const resolvedLabel = label ?? getTagLabel(tag, settings);
+
+  if (
+    resolvedLabel.length < MIN_TAG_LENGTH ||
+    resolvedLabel.length > MAX_TAG_LENGTH
+  ) {
+    throw new BadRequestError(
+      `Tag names must be between ${MIN_TAG_LENGTH} and ${MAX_TAG_LENGTH} characters long.`,
+    );
+  }
+
+  const duplicateLabel = (existing?.tags || []).some(
+    (existingTag) =>
+      existingTag !== tag &&
+      getTagLabel(existingTag, settings) === resolvedLabel,
+  );
+  if (duplicateLabel) {
+    throw new BadRequestError("A tag with this name already exists.");
+  }
+
+  settings[tag] = { color, description, label: resolvedLabel };
 
   await TagModel.updateOne(
     { organization },

--- a/packages/back-end/src/models/TagModel.ts
+++ b/packages/back-end/src/models/TagModel.ts
@@ -19,6 +19,11 @@ const TagModel = mongoose.model<TagDBInterface>("Tag", tagSchema);
 const MIN_TAG_LENGTH = 2;
 const MAX_TAG_LENGTH = 64;
 
+type AddTagOptions = {
+  label?: string;
+  createOnly?: boolean;
+};
+
 function getTagLabel(
   tag: string,
   settings: TagDBInterface["settings"],
@@ -75,8 +80,10 @@ export async function addTag(
   tag: string,
   color: string,
   description: string,
-  label?: string,
+  options: AddTagOptions = {},
 ) {
+  const { label, createOnly = false } = options;
+
   if (tag.length < MIN_TAG_LENGTH || tag.length > MAX_TAG_LENGTH) {
     throw new Error(
       `Tags must be at between ${MIN_TAG_LENGTH} and ${MAX_TAG_LENGTH} characers long.`,
@@ -89,6 +96,12 @@ export async function addTag(
   const existing = await TagModel.findOne({
     organization,
   });
+  if (createOnly && existing?.tags?.includes(tag)) {
+    throw new BadRequestError(
+      "A tag with this name already exists or was previously renamed.",
+    );
+  }
+
   const settings = existing?.settings || {};
   const resolvedLabel = label ?? getTagLabel(tag, settings);
 

--- a/packages/back-end/src/routers/tag/tag.controller.ts
+++ b/packages/back-end/src/routers/tag/tag.controller.ts
@@ -34,9 +34,9 @@ export const postTag = async (
   if (!context.permissions.canCreateAndUpdateTag()) {
     context.permissions.throwPermissionError();
   }
-  const { id, color, description } = req.body;
+  const { id, color, description, label } = req.body;
 
-  await addTag(context.org.id, id, color, description);
+  await addTag(context.org.id, id, color, description, label);
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/routers/tag/tag.controller.ts
+++ b/packages/back-end/src/routers/tag/tag.controller.ts
@@ -13,7 +13,11 @@ import { removeTagFromExperiments } from "back-end/src/models/ExperimentModel";
 
 // region POST /tag
 
-type CreateTagRequest = AuthRequest<TagInterface>;
+type CreateTagRequest = AuthRequest<
+  TagInterface & {
+    createOnly?: boolean;
+  }
+>;
 
 type CreateTagResponse = {
   status: 200;
@@ -34,9 +38,12 @@ export const postTag = async (
   if (!context.permissions.canCreateAndUpdateTag()) {
     context.permissions.throwPermissionError();
   }
-  const { id, color, description, label } = req.body;
+  const { id, color, description, label, createOnly } = req.body;
 
-  await addTag(context.org.id, id, color, description, label);
+  await addTag(context.org.id, id, color, description, {
+    label,
+    createOnly,
+  });
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/routers/tag/tag.router.ts
+++ b/packages/back-end/src/routers/tag/tag.router.ts
@@ -16,6 +16,7 @@ router.post(
         id: z.string(),
         color: z.string(),
         description: z.string(),
+        label: z.string().optional(),
       })
       .strict(),
   }),

--- a/packages/back-end/src/routers/tag/tag.router.ts
+++ b/packages/back-end/src/routers/tag/tag.router.ts
@@ -17,6 +17,7 @@ router.post(
         color: z.string(),
         description: z.string(),
         label: z.string().optional(),
+        createOnly: z.boolean().optional(),
       })
       .strict(),
   }),

--- a/packages/back-end/test/api/tags.test.ts
+++ b/packages/back-end/test/api/tags.test.ts
@@ -163,6 +163,38 @@ describe("tags API", () => {
     expect(await getAllTags("org1")).toHaveLength(1);
   });
 
+  it("does not overwrite a renamed tag when creating with its hidden id", async () => {
+    await postTag({
+      id: "backend",
+      label: "Backend Engineering",
+      color: "blue",
+      description: "Original tag",
+      createOnly: true,
+    });
+
+    const response = await postTag({
+      id: "backend",
+      label: "backend",
+      color: "gold",
+      description: "Should not overwrite",
+      createOnly: true,
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      status: 400,
+      message: "A tag with this name already exists or was previously renamed.",
+    });
+    expect(await getAllTags("org1")).toEqual([
+      {
+        id: "backend",
+        label: "Backend Engineering",
+        color: "blue",
+        description: "Original tag",
+      },
+    ]);
+  });
+
   it("stores tag ids containing dots as literal settings keys", async () => {
     const response = await postTag({
       id: "backend.api",

--- a/packages/back-end/test/api/tags.test.ts
+++ b/packages/back-end/test/api/tags.test.ts
@@ -1,0 +1,204 @@
+import mongoose from "mongoose";
+import request from "supertest";
+import { getAllTags } from "back-end/src/models/TagModel";
+import { getAuthConnection } from "back-end/src/services/auth";
+import { setupApp } from "./api.setup";
+
+jest.mock("back-end/src/services/auth", () => {
+  const actual = jest.requireActual("back-end/src/services/auth");
+  const middleware = jest.fn();
+  return {
+    ...actual,
+    getAuthConnection: () => ({ middleware }),
+    processJWT: jest.fn((req, _res, next) => {
+      req.organization = {
+        id: "org1",
+        name: "Tags API",
+        ownerEmail: "test@test.com",
+        url: "",
+        dateCreated: new Date(),
+        members: [{ id: "user1", role: "admin" }],
+        settings: {},
+      };
+      req.currentUser = {
+        id: "user1",
+        email: "test@test.com",
+        name: "Test User",
+        verified: true,
+        superAdmin: true,
+      };
+      req.userId = "user1";
+      req.email = "test@test.com";
+      req.name = "Test User";
+      req.superAdmin = true;
+      req.teams = [];
+      next();
+    }),
+  };
+});
+
+describe("tags API", () => {
+  const { app, isReady } = setupApp();
+
+  beforeEach(async () => {
+    await isReady;
+    getAuthConnection().middleware.mockImplementation((_req, _res, next) =>
+      next(),
+    );
+  });
+
+  async function postTag(body: Record<string, unknown>) {
+    return request(app).post("/tag").send(body);
+  }
+
+  it("continues accepting the legacy tag payload without a label", async () => {
+    const response = await postTag({
+      id: "backend",
+      color: "blue",
+      description: "Backend work",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await getAllTags("org1")).toEqual([
+      {
+        id: "backend",
+        label: "backend",
+        color: "blue",
+        description: "Backend work",
+      },
+    ]);
+  });
+
+  it("accepts an editable label", async () => {
+    const response = await postTag({
+      id: "backend",
+      label: "Backend Engineering",
+      color: "blue",
+      description: "Backend work",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await getAllTags("org1")).toEqual([
+      {
+        id: "backend",
+        label: "Backend Engineering",
+        color: "blue",
+        description: "Backend work",
+      },
+    ]);
+  });
+
+  it("rejects invalid and unknown label properties", async () => {
+    const invalidLabel = await postTag({
+      id: "backend",
+      label: 123,
+      color: "blue",
+      description: "",
+    });
+    const unknownProperty = await postTag({
+      id: "backend",
+      label: "Backend",
+      color: "blue",
+      description: "",
+      unexpected: true,
+    });
+
+    expect(invalidLabel.status).toBe(400);
+    expect(unknownProperty.status).toBe(400);
+    expect(await getAllTags("org1")).toEqual([]);
+  });
+
+  it("preserves a renamed label when a legacy caller updates the tag", async () => {
+    await postTag({
+      id: "backend",
+      label: "Backend Engineering",
+      color: "blue",
+      description: "Backend work",
+    });
+
+    const response = await postTag({
+      id: "backend",
+      color: "teal",
+      description: "Backend services",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await getAllTags("org1")).toEqual([
+      {
+        id: "backend",
+        label: "Backend Engineering",
+        color: "teal",
+        description: "Backend services",
+      },
+    ]);
+  });
+
+  it("rejects duplicate labels but allows updating the same tag", async () => {
+    await postTag({
+      id: "backend",
+      label: "Backend Engineering",
+      color: "blue",
+      description: "",
+    });
+
+    const sameTag = await postTag({
+      id: "backend",
+      label: "Backend Engineering",
+      color: "teal",
+      description: "Updated",
+    });
+    const duplicate = await postTag({
+      id: "platform",
+      label: "Backend Engineering",
+      color: "gold",
+      description: "",
+    });
+
+    expect(sameTag.status).toBe(200);
+    expect(duplicate.status).toBe(400);
+    expect(duplicate.body).toEqual({
+      status: 400,
+      message: "A tag with this name already exists.",
+    });
+    expect(await getAllTags("org1")).toHaveLength(1);
+  });
+
+  it("stores tag ids containing dots as literal settings keys", async () => {
+    const response = await postTag({
+      id: "backend.api",
+      label: "Backend API",
+      color: "blue",
+      description: "",
+    });
+    const document = await mongoose.connection
+      .collection("tags")
+      .findOne({ organization: "org1" });
+
+    expect(response.status).toBe(200);
+    expect(document?.settings["backend.api"]).toEqual({
+      color: "blue",
+      description: "",
+      label: "Backend API",
+    });
+    expect(document?.settings.backend).toBeUndefined();
+  });
+
+  it("enforces the tag name length for labels", async () => {
+    const tooShort = await postTag({
+      id: "backend",
+      label: "x",
+      color: "blue",
+      description: "",
+    });
+    const tooLong = await postTag({
+      id: "platform",
+      label: "x".repeat(65),
+      color: "blue",
+      description: "",
+    });
+
+    expect(tooShort.status).toBe(400);
+    expect(tooLong.status).toBe(400);
+    expect(await getAllTags("org1")).toEqual([]);
+  });
+});

--- a/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
@@ -59,7 +59,7 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
   isModalOpen,
   editError,
 }) => {
-  const { getProjectById } = useDefinitions();
+  const { getProjectById, getTagById } = useDefinitions();
   const permissionsUtils = usePermissionsUtil();
   const workspaceUIEnabled = useFeatureIsOn("slack-workspace-ui");
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -355,7 +355,7 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
                   {tags.map((tag) => (
                     <Badge
                       key={tag}
-                      label={tag}
+                      label={getTagById(tag)?.label ?? tag}
                       color="purple"
                       variant="soft"
                     />

--- a/packages/front-end/components/Learnings/FindLearningsModal.tsx
+++ b/packages/front-end/components/Learnings/FindLearningsModal.tsx
@@ -13,6 +13,7 @@ import Modal from "@/ui/Modal";
 import Checkbox from "@/ui/Checkbox";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import { useAuth } from "@/services/auth";
+import { useDefinitions } from "@/services/DefinitionsContext";
 import ExperimentChips from "./ExperimentChips";
 
 type SuggestionState = {
@@ -35,6 +36,7 @@ const FindLearningsModal: FC<{
   onSaved?: () => void;
 }> = ({ experiments, saveProjects, close, onSaved }) => {
   const { apiCall } = useAuth();
+  const { getTagById } = useDefinitions();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [suggestions, setSuggestions] = useState<SuggestionState[]>([]);
@@ -310,7 +312,7 @@ const FindLearningsModal: FC<{
                             {s.suggestion.tags.map((t) => (
                               <Badge
                                 key={t}
-                                label={t}
+                                label={getTagById(t)?.label ?? t}
                                 color="violet"
                                 variant="soft"
                                 size="sm"

--- a/packages/front-end/components/Learnings/SavedLearningsList.tsx
+++ b/packages/front-end/components/Learnings/SavedLearningsList.tsx
@@ -45,7 +45,11 @@ const SavedLearningsList: FC<{
 }> = ({ learnings, experiments, mutate }) => {
   const { apiCall } = useAuth();
   const { getOwnerDisplay } = useUser();
-  const { projects: orgProjects, getProjectById } = useDefinitions();
+  const {
+    projects: orgProjects,
+    getProjectById,
+    getTagById,
+  } = useDefinitions();
   const orgSettings = useOrgSettings();
   const { aiEnabled } = useAISettings();
   const learningStatuses =
@@ -542,7 +546,7 @@ const SavedLearningsList: FC<{
                           aria-pressed={active}
                         >
                           <Badge
-                            label={t}
+                            label={getTagById(t)?.label ?? t}
                             color="violet"
                             variant={active ? "solid" : "soft"}
                             size="sm"

--- a/packages/front-end/components/SlackIntegrations/SlackIntegrationsListView/SlackIntegrationsListItem/SlackIntegrationsListItem.tsx
+++ b/packages/front-end/components/SlackIntegrations/SlackIntegrationsListView/SlackIntegrationsListItem/SlackIntegrationsListItem.tsx
@@ -3,6 +3,7 @@ import { FaPencilAlt } from "react-icons/fa";
 import { SlackIntegrationInterface } from "shared/types/slack-integration";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
 import { SlackIntegrationEditParams } from "@/components/SlackIntegrations/slack-integrations-utils";
+import { useDefinitions } from "@/services/DefinitionsContext";
 
 type SlackIntegrationsListItemProps = {
   slackIntegration: SlackIntegrationInterface;
@@ -17,6 +18,7 @@ export const SlackIntegrationsListItem: FC<SlackIntegrationsListItemProps> = ({
   onEditModalOpen,
   projectsMap,
 }) => {
+  const { getTagById } = useDefinitions();
   const onEdit = useCallback(() => {
     onEditModalOpen(slackIntegration.id, slackIntegration);
   }, [slackIntegration, onEditModalOpen]);
@@ -102,7 +104,7 @@ export const SlackIntegrationsListItem: FC<SlackIntegrationsListItemProps> = ({
               ) : (
                 slackIntegration.tags.map((tag) => (
                   <span key={tag} className="mr-2 badge badge-purple">
-                    {tag}
+                    {getTagById(tag)?.label ?? tag}
                   </span>
                 ))
               )}

--- a/packages/front-end/components/Tags/LinkedTag.tsx
+++ b/packages/front-end/components/Tags/LinkedTag.tsx
@@ -19,8 +19,9 @@ export default function LinkedTag({
   ...tagProps
 }: Props) {
   const { getTagById } = useDefinitions();
-  const description =
-    tagProps.description ?? getTagById(tag)?.description ?? "";
+  const fullTag = getTagById(tag);
+  const description = tagProps.description ?? fullTag?.description ?? "";
+  const tagDisplayName = fullTag?.label ?? tag;
 
   const link = (
     <Link
@@ -30,14 +31,14 @@ export default function LinkedTag({
       onClick={onTagClick ? (e) => onTagClick(tag, e) : undefined}
       style={{ color: "inherit" }}
     >
-      {tag}
+      {tagDisplayName}
     </Link>
   );
 
   const tooltipContent = entity ? (
     <>
       <Box>
-        View other {entity} with the <strong>{tag}</strong> tag
+        View other {entity} with the <strong>{tagDisplayName}</strong> tag
       </Box>
       {description && <Box mt="2">{description}</Box>}
     </>

--- a/packages/front-end/components/Tags/Tag.tsx
+++ b/packages/front-end/components/Tags/Tag.tsx
@@ -40,14 +40,19 @@ export default function Tag({
 }: TagProps) {
   const { getTagById } = useDefinitions();
   const fullTag = getTagById(tag);
+  const tagDisplayName = fullTag?.label ?? tag;
   const desc = description ?? fullTag?.description ?? "";
   // Suppressed when a label is provided so wrappers can own hover affordance.
-  const displayTitle = label ? undefined : tag + (desc ? `\n\n${desc}` : "");
+  const displayTitle = label
+    ? undefined
+    : tagDisplayName + (desc ? `\n\n${desc}` : "");
   const tagColor = (color ?? fullTag?.color ?? "blue") as RadixColor;
-  const content = label ?? tag;
+  const content = label ?? tagDisplayName;
 
-  const truncate = maxChars != null && tag.length > maxChars;
-  const displayLabel = truncate ? `${tag.slice(0, maxChars)}…` : tag;
+  const truncate = maxChars != null && tagDisplayName.length > maxChars;
+  const displayLabel = truncate
+    ? `${tagDisplayName.slice(0, maxChars)}…`
+    : tagDisplayName;
   const badgeStyle =
     truncate || maxChars != null
       ? {
@@ -63,7 +68,7 @@ export default function Tag({
       <Flex
         gap="2"
         align="center"
-        title={truncate ? tag : displayTitle}
+        title={truncate ? tagDisplayName : displayTitle}
         mr={skipMargin ? undefined : "2"}
         mb={skipMargin ? undefined : "1"}
         style={maxChars != null ? badgeStyle : { maxWidth, overflow: "hidden" }}
@@ -94,7 +99,7 @@ export default function Tag({
       </Flex>
     );
     return truncate ? (
-      <Tooltip body={tag} flipTheme={false}>
+      <Tooltip body={tagDisplayName} flipTheme={false}>
         {dotMark}
       </Tooltip>
     ) : (
@@ -115,7 +120,7 @@ export default function Tag({
     />
   );
   return truncate ? (
-    <Tooltip body={tag} flipTheme={false}>
+    <Tooltip body={tagDisplayName} flipTheme={false}>
       {badge}
     </Tooltip>
   ) : (

--- a/packages/front-end/components/Tags/TagsInput.tsx
+++ b/packages/front-end/components/Tags/TagsInput.tsx
@@ -122,13 +122,16 @@ const TagsInput: FC<{
       legacyHeight
       options={
         tagOptions.map((t) => {
+          const fullTag = getTagById(t.id);
           // Converts Radix color to hex color to make it compatible with MultiSelectField
-          const hexColor = TAG_COLORS_MAP[t.color] ?? DEFAULT_TAG_COLOR;
+          const hexColor =
+            TAG_COLORS_MAP[t.color ?? fullTag?.color ?? "blue"] ??
+            DEFAULT_TAG_COLOR;
           return {
             value: t.id,
-            label: t.id,
+            label: t.label ?? fullTag?.label ?? t.id,
             color: hexColor || "var(--slate-12)",
-            tooltip: t.description,
+            tooltip: t.description ?? fullTag?.description ?? "",
           };
         }) ?? []
       }

--- a/packages/front-end/components/Tags/TagsModal.tsx
+++ b/packages/front-end/components/Tags/TagsModal.tsx
@@ -33,6 +33,7 @@ export default function TagsModal({
       id: existing?.id || "",
       color: existing?.color || "blue",
       description: existing?.description || "",
+      label: existing?.label ?? existing?.id ?? "",
     },
   });
   const { apiCall } = useAuth();
@@ -50,31 +51,38 @@ export default function TagsModal({
       open={true}
       close={close}
       cta={existing?.id ? "Save Changes" : "Create Tag"}
-      header={existing?.id ? `Edit Tag: ${existing.id}` : "Create Tag"}
+      header={
+        existing?.id
+          ? `Edit Tag: ${existing.label ?? existing.id}`
+          : "Create Tag"
+      }
       submit={form.handleSubmit(async (value) => {
+        const label = value.label ?? value.id;
         await apiCall(`/tag`, {
           method: "POST",
-          body: JSON.stringify(value),
+          body: JSON.stringify({
+            ...value,
+            id: existing?.id ?? label,
+            label,
+          }),
         });
         await onSuccess();
       })}
     >
       <div>
-        {!existing?.id && (
-          <Container mb="3">
-            <Text as="label" size="3" weight="medium">
-              Name
-            </Text>
-            <Field
-              size="legacy"
-              minLength={2}
-              maxLength={64}
-              className=""
-              required
-              {...form.register("id")}
-            />
-          </Container>
-        )}
+        <Container mb="3">
+          <Text as="label" size="3" weight="medium">
+            Name
+          </Text>
+          <Field
+            size="legacy"
+            minLength={2}
+            maxLength={64}
+            className=""
+            required
+            {...form.register("label")}
+          />
+        </Container>
         <Select
           label="Color"
           value={form.watch("color")}
@@ -105,9 +113,10 @@ export default function TagsModal({
             Preview
           </Text>
           <div>
-            {form.watch("id") && (
+            {(existing?.id || form.watch("label")) && (
               <Tag
-                tag={form.watch("id")}
+                tag={existing?.id ?? form.watch("label") ?? ""}
+                label={form.watch("label")}
                 color={form.watch("color") as RadixColor}
                 description={form.watch("description")}
                 skipMargin

--- a/packages/front-end/components/Tags/TagsModal.tsx
+++ b/packages/front-end/components/Tags/TagsModal.tsx
@@ -64,6 +64,7 @@ export default function TagsModal({
             ...value,
             id: existing?.id ?? label,
             label,
+            createOnly: !existing?.id,
           }),
         });
         await onSuccess();

--- a/packages/front-end/pages/learnings/[lid].tsx
+++ b/packages/front-end/pages/learnings/[lid].tsx
@@ -33,7 +33,7 @@ const LearningPage = (): React.ReactElement => {
 
   const { apiCall } = useAuth();
   const { getOwnerDisplay } = useUser();
-  const { getProjectById } = useDefinitions();
+  const { getProjectById, getTagById } = useDefinitions();
   const orgSettings = useOrgSettings();
   const { aiEnabled } = useAISettings();
   const learningStatuses =
@@ -222,7 +222,7 @@ const LearningPage = (): React.ReactElement => {
               {learning.tags.map((t) => (
                 <Badge
                   key={t}
-                  label={t}
+                  label={getTagById(t)?.label ?? t}
                   color="violet"
                   variant="soft"
                   size="sm"

--- a/packages/front-end/pages/settings/tags.tsx
+++ b/packages/front-end/pages/settings/tags.tsx
@@ -29,9 +29,9 @@ const TagsPage: FC = () => {
     useSearch({
       items: tags || [],
       localStorageKey: "tags",
-      defaultSortField: "id",
+      defaultSortField: "label",
       defaultSortDir: 1,
-      searchFields: ["id^2", "description"],
+      searchFields: ["label^2", "id", "description"],
       pageSize: 50,
       updateSearchQueryOnChange: true,
     });
@@ -97,7 +97,7 @@ const TagsPage: FC = () => {
             >
               <thead>
                 <tr>
-                  <SortableTH field="id" style={{ width: "30%" }}>
+                  <SortableTH field="label" style={{ width: "30%" }}>
                     Tag name
                   </SortableTH>
                   <th style={{ width: "30%" }}>Preview</th>
@@ -118,10 +118,10 @@ const TagsPage: FC = () => {
                             setModalOpen(t);
                           }}
                         >
-                          {t.id}
+                          {t.label ?? t.id}
                         </a>
                       ) : (
-                        <span>{t.id}</span>
+                        <span>{t.label ?? t.id}</span>
                       )}
                     </td>
                     <td className="text-gray">

--- a/packages/shared/types/tag.d.ts
+++ b/packages/shared/types/tag.d.ts
@@ -2,6 +2,7 @@ export interface TagInterface {
   id: string;
   color: string;
   description: string;
+  label?: string;
 }
 
 export interface TagDBInterface {
@@ -13,4 +14,5 @@ export interface TagDBInterface {
 export interface TagSettings {
   color: string;
   description: string;
+  label?: string;
 }


### PR DESCRIPTION
## What changed

Tags previously used their name as their identifier, so changing the name could break references to that tag.

This change:
- keeps the existing tag ID stable
- adds a separate editable display name (`label`)
- shows the display name throughout the UI while filters and stored references continue using the stable ID
- preserves compatibility with existing tags and older API clients
- prevents duplicate display names
- rejects create-form collisions with the hidden ID of a previously renamed tag before any data is changed
- keeps tag IDs containing special characters such as `.` working correctly

## Testing

- Added backend API tests for legacy payloads, renaming, duplicate names, hidden-ID collisions, validation, and tag IDs containing dots
- Backend and frontend TypeScript checks pass
- Lint, formatting, and diff checks pass
- Live-tested locally by creating `live.tag.2694`, renaming it, reloading the UI, and confirming MongoDB retained the original ID while storing the new display name

Fixes #2694